### PR TITLE
Add support for Cilium Enterprise OLM installation

### DIFF
--- a/class/cilium.yml
+++ b/class/cilium.yml
@@ -7,7 +7,7 @@ parameters:
     olm:
       dependencies:
         - type: https
-          source: https://github.com/cilium/cilium-olm/archive/master.tar.gz
+          source: ${cilium:olm:source:${cilium:release}}
           output_path: dependencies/cilium/olm/cilium/cilium-olm/
           unpack: true
 

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -31,7 +31,12 @@ parameters:
           enabled: false
 
     olm:
-      version: "1.10.4"
+      source:
+        opensource: https://github.com/cilium/cilium-olm/archive/master.tar.gz
+        enterprise: <CILIUM-ENTERPRISE-OLM-MANIFESTS-TARGZ-URL> # Configure the URL in your global defaults.
+      version: "1.10"
+      patchlevel: "4"
+      full_version: ${cilium:olm:version}.${cilium:olm:patchlevel}
 
     charts:
       cilium:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -27,7 +27,7 @@ The Cilium OLM is a thin wrapper around Helm, because of this the Helm values ar
 |✅
 |Enterprise
 |✅
-|⛔️
+|✅
 |===
 
 == `release`
@@ -39,7 +39,6 @@ possible values:: `opensource`, `enterprise`
 
 Two version of Cilium exist.
 The open-source version and the enterprise version.
-Currently there exists no enterprise version of the OLM installation.
 
 
 == `charts.cilium.source`
@@ -89,14 +88,64 @@ default:: https://github.com/projectsyn/component-cilium/blob/master/class/defau
 
 The version to use for the `cilium-enterprise` Helm chart.
 
+== `olm.source`
+
+[horizontal]
+type:: object
+default::
++
+[source,yaml]
+----
+opensource: https://github.com/cilium/cilium-olm/archive/master.tar.gz
+enterprise: <CILIUM-ENTERPRISE-OLM-MANIFESTS-TARGZ-URL>
+----
+
+The source for the OLM manifests.
+The component selects the `opensource` or `enterprise` field based on the value of component parameter `release`.
+The component doesn't provide the URL of the Cilium Enterprise OLM manifests `.tar.gz` archive.
+Users must provide the URL themselves in their Project Syn configuration hierarchy.
+
+TIP: The component default is an invalid string (`<CILIUM-ENTERPRISE-OLM-MANIFESTS-TARGZ-URL>`) instead of `~` to make the Kapitan error message somewhat useful when the user hasn't reconfigured the chart repository.
+
+=== Example
+
+[source,yaml]
+----
+parameters:
+  cilium:
+    olm:
+      source:
+        enterprise: https://cilium-ee.example.com/downloads/v${cilium:olm:version}/cilium-ee-${cilium:olm:full_version}.tar.gz <1>
+----
+<1> The example configuration uses Reclass references to construct URL parts containing the desired version.
+The component explicitly provides separate parameters for the OLM minor version and patchlevel.
+
 == `olm.version`
 
 [horizontal]
 type:: string
-example:: `1.10.4`
+example:: `1.10`
+default:: https://github.com/projectsyn/component-cilium/blob/master/class/defaults.yml[See `class/defaults.yml`]
 
-The version of the downloaded OLM release.
+The minor version of the OLM release to download.
 
+== `olm.patchlevel`
+
+[horizontal]
+type:: string
+example:: `4`
+default:: https://github.com/projectsyn/component-cilium/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+The patch level of the OLM release to download.
+
+== `olm.full_version`
+
+[horizontal]
+type:: string
+default:: `${cilium:olm:version}.${cilium:olm:patchlevel}`
+
+The complete version of the OLM release to download.
+By default, the component constructs the value for this parameter from parameters `version` and `patchlevel`.
 
 == `cilium_helm_values`
 


### PR DESCRIPTION
This commit prepares the component to support both opensource and enterprise OLM installations.

The component, however, doesn't provide the Enterprise OLM .tar.gz URL. Users must provide the URL themselves in their Project Syn configuration in parameter `cilium.olm.source.enterprise`.

Fixes #16




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
