### PR TITLE
Make Cilium operator resource requests & limits configurable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -45,6 +45,13 @@ parameters:
       version: "1.10"
       patchlevel: "4"
       full_version: ${cilium:olm:version}.${cilium:olm:patchlevel}
+      resources:
+        requests:
+          cpu: 100m
+          memory: 250Mi
+        limits:
+          cpu: 100m
+          memory: 250Mi
 
     charts:
       cilium:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -29,6 +29,14 @@ parameters:
       prometheus:
         serviceMonitor:
           enabled: false
+      operator:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 250Mi
+          limits:
+            cpu: 100m
+            memory: 250Mi
 
     olm:
       source:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -147,14 +147,22 @@ default:: `${cilium:olm:version}.${cilium:olm:patchlevel}`
 The complete version of the OLM release to download.
 By default, the component constructs the value for this parameter from parameters `version` and `patchlevel`.
 
+== `olm.resources`
+
+[horizontal]
+type:: object
+default:: https://github.com/projectsyn/component-cilium/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+The resource requests and limits for the Cilium OLM Deployment.
+
 == `cilium_helm_values`
 
 [horizontal]
 type:: object
+default:: https://github.com/projectsyn/component-cilium/blob/master/class/defaults.yml[See `class/defaults.yml`]
 
 The configuration values of the underlying Cilium helm chart.
 See https://docs.cilium.io/en/{helm-minor-version}/helm-reference/[Reference].
-
 
 == `helm_values`
 

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator-deployment.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator-deployment.yaml
@@ -69,6 +69,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
           name: cilium-operator
+          resources:
+            limits:
+              cpu: 100m
+              memory: 250Mi
+            requests:
+              cpu: 100m
+              memory: 250Mi
           volumeMounts:
             - mountPath: /tmp/cilium/config-map
               name: cilium-config-path

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator-deployment.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator-deployment.yaml
@@ -69,6 +69,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
           name: cilium-operator
+          resources:
+            limits:
+              cpu: 100m
+              memory: 250Mi
+            requests:
+              cpu: 100m
+              memory: 250Mi
           volumeMounts:
             - mountPath: /tmp/cilium/config-map
               name: cilium-config-path

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -39,10 +39,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 150Mi
+              memory: 250Mi
             requests:
               cpu: 100m
-              memory: 150Mi
+              memory: 250Mi
           volumeMounts:
             - mountPath: /tmp
               name: tmp

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.10.4-x5bfd7b3-clusterserviceversion.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.10.4-x5bfd7b3-clusterserviceversion.yaml
@@ -178,10 +178,10 @@ spec:
                     resources:
                       limits:
                         cpu: 100m
-                        memory: 150Mi
+                        memory: 250Mi
                       requests:
                         cpu: 100m
-                        memory: 150Mi
+                        memory: 250Mi
                     volumeMounts:
                       - mountPath: /tmp
                         name: tmp

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -19,6 +19,14 @@ spec:
       clusterPoolIPv4PodCIDR: 10.128.0.0/14
   kubeProxyReplacement: probe
   nativeRoutingCIDR: 10.128.0.0/14
+  operator:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 250Mi
+      requests:
+        cpu: 100m
+        memory: 250Mi
   prometheus:
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
This is mainly dealing with making the operator resource requests and limits configurable for OLM installatations, since we need to make sure that all the sources which configure the operator deploykment for OLM installations agree on the operator's resource requests and limits.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
