### PR TITLE
Remove default value for `nativeRoutingCIDR`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -25,7 +25,6 @@ parameters:
           clusterPoolIPv4MaskSize: "23"
           clusterPoolIPv4PodCIDR: 10.128.0.0/14
       kubeProxyReplacement: probe
-      nativeRoutingCIDR: 10.128.0.0/14
       prometheus:
         serviceMonitor:
           enabled: false

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -47,7 +47,6 @@ data:
   monitor-aggregation: medium
   monitor-aggregation-flags: all
   monitor-aggregation-interval: 5s
-  native-routing-cidr: 10.128.0.0/14
   node-port-bind-protection: 'true'
   operator-api-serve-addr: 127.0.0.1:9234
   preallocate-bpf-maps: 'false'

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -47,7 +47,6 @@ data:
   monitor-aggregation: medium
   monitor-aggregation-flags: all
   monitor-aggregation-interval: 5s
-  native-routing-cidr: 10.128.0.0/14
   node-port-bind-protection: 'true'
   operator-api-serve-addr: 127.0.0.1:9234
   preallocate-bpf-maps: 'false'

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -18,7 +18,6 @@ spec:
       clusterPoolIPv4MaskSize: '23'
       clusterPoolIPv4PodCIDR: 10.128.0.0/14
   kubeProxyReplacement: probe
-  nativeRoutingCIDR: 10.128.0.0/14
   operator:
     resources:
       limits:


### PR DESCRIPTION
This parameter is only used for Cilium's "Native-Routing" mode (cf. https://docs.cilium.io/en/v1.11/concepts/networking/routing/#native-routing), which is not enabled by default.

This PR removes the parameter from the default configuration since it has no effect on its own.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
