### PR TITLE
Create aggregated clusterroles for `cilium.io` resources

### DIFF
--- a/class/cilium.yml
+++ b/class/cilium.yml
@@ -22,6 +22,11 @@ parameters:
           input_type: jsonnet
           output_path: ${_instance}/olm/
 
+        - input_paths:
+            - ${_base_directory}/component/aggregated-clusterroles.jsonnet
+          input_type: jsonnet
+          output_path: ${_instance}/
+
     helm:
       dependencies:
         - type: helm
@@ -40,6 +45,10 @@ parameters:
             - cilium/component/helm-namespace.jsonnet
           input_type: jsonnet
           output_path: ${_instance}/01_cilium_helmchart
+        - input_paths:
+            - ${_base_directory}/component/aggregated-clusterroles.jsonnet
+          input_type: jsonnet
+          output_path: ${_instance}/
         - output_path: ${_instance}/01_cilium_helmchart
           input_type: helm
           output_type: yaml

--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -1,0 +1,73 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local ciliumRule(resources) =
+  {
+    apiGroups: [ 'cilium.io' ],
+    resources: resources,
+    verbs: [
+      'get',
+      'list',
+      'watch',
+    ],
+  };
+
+local view = kube.ClusterRole('syn-cilium-view') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+    },
+  },
+  rules: [
+    // ciliumnetworkpolicies and ciliumendpoints are namespace-scoped, so we
+    // aggregate them to `view`, `ciliumconfigs` as well, but the operator
+    // already creates aggregations for that one.
+    ciliumRule([ 'networkpolicies', 'ciliumendpoints' ]),
+  ],
+};
+
+local edit = kube.ClusterRole('syn-cilium-edit') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+    },
+  },
+  rules: [
+    // ciliumnetworkpolicies and ciliumendpoints are namespace-scoped, so we
+    // aggregate them to `view`, `ciliumconfigs` as well, but the operator
+    // already creates aggregations for that one.
+    ciliumRule([ 'networkpolicies' ]) {
+      verbs: [
+        'create',
+        'delete',
+        'deletecollection',
+        'patch',
+        'update',
+      ],
+    },
+  ],
+};
+
+local cluster_reader = kube.ClusterRole('syn-cilium-cluster-reader') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+    },
+  },
+  rules: [
+    // We could explicitly list and maintain cluster-scoped resources here, but
+    // that's overhead we don't really need, so we just grant "view" permissions
+    // on all resources in `cilium.io` to `cluster-reader`.
+    ciliumRule([ '*' ]),
+  ],
+};
+
+{
+  '02_aggregated_clusterroles': [
+    view,
+    edit,
+    cluster_reader,
+  ],
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,39 @@
 = Cilium
 
-cilium is a Commodore component to manage Cilium.
+cilium is a Commodore component to manage the Cilium networkplugin.
 
-See the xref:references/parameters.adoc[parameters] reference for further details.
+See the xref:references/parameters.adoc[parameters] reference for further details on how to use the component to configure and deploy Cilium.
+
+== Aggregated permissions
+
+The component creates the following `ClusterRoles` which are aggregated to the cluster's default `ClusterRoles`:
+
+[cols="1,1,1"]
+|===
+|Name |Resources |Aggregated to
+
+|`syn-cilium-view`
+a|
+* `ciliumnetworkpolicies.cilium.io`
+* `ciliumendpoints.cilium.io`
+a|
+* `view`
+* `edit`
+* `admin`
+
+|`syn-cilium-edit`
+a|
+* `ciliumnetworkpolicies.cilium.io`
+a|
+* `edit`
+* `admin`
+
+|`syn-cilium-cluster-reader`
+|All resources in `cilium.io`
+|`cluster-reader`
+
+|===
+
+This enables users to viewfootnote:view[View permission grants RBAC verbs `get`, `list` and `watch`] `ciliumnetworkpolicy` and `ciliumendpoint` resources in their namespaces.
+Users which have `edit` or `admin` permissions in a namespace, can additionally create, modify, and delete `ciliumnetworkpolicy` resources in that namespace.
+Finally, users which have `cluster-reader` permissions can viewfootnote:view[] at all resources in `cilium.io` in all namespaces.

--- a/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-cilium-view
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+      - ciliumendpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn-cilium-edit
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-cilium-cluster-reader
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-cilium-view
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+      - ciliumendpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn-cilium-edit
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-cilium-cluster-reader
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-cilium-view
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+      - ciliumendpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn-cilium-edit
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-cilium-cluster-reader
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
We aggregate `ciliumnetworkpolicies` to `view` and `edit`, `ciliumendpoints` to `view`, and all resources in `cilium.io` to `cluster-reader`.

As far as I can see, it's fine to allow users to manage `ciliumnetworkpolicies` and view `ciliumendpoints` in their namespaces.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
