### PR TITLE
Make Cilium OLM tar-ball loading more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@
 /_public
 
 # Additional entries
-dependencies/cilium/olm/
-jsonnetfile.json
+/dependencies/cilium/olm
+/jsonnetfile.json
+/olm

--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -6,10 +6,20 @@ local inv = kap.inventory();
 local params = inv.parameters.cilium;
 
 local olmDir =
+  local prefix = '%s/olm/cilium/cilium-olm/' % inv.parameters._base_directory;
   if params.release == 'opensource' then
-    'dependencies/cilium/olm/cilium/cilium-olm/cilium-olm-master/manifests/cilium.v%s/' % params.olm.full_version
+    prefix + 'cilium-olm-master/manifests/cilium.v%s/' % params.olm.full_version
   else if params.release == 'enterprise' then
-    'dependencies/cilium/olm/cilium/cilium-olm/cilium.v%s/' % params.olm.full_version
+    local newpath = 'tmp/cilium-ee-olm/manifests/';
+    local manifests_dir = 'cilium.v%s/' % params.olm.full_version;
+    if kap.file_exists(prefix + manifests_dir).exists then
+      prefix + manifests_dir
+    else if kap.file_exists(prefix + newpath + manifests_dir).exists then
+      prefix + newpath + manifests_dir
+    else
+      error
+        'Unable to find manifests path for Cilium EE %s. ' % params.olm.full_version
+        + 'Check structure of .tar.gz and update component.'
   else
     error "Unknown release '%s'" % [ params.release ];
 

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -158,14 +158,10 @@ spec:
         - command:
             - sh
             - -ec
-            - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount"
-              $CGROUP_ROOT;
-
+            - |
+              cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
               rm /hostbin/cilium-mount
-
-              '
           env:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -158,14 +158,10 @@ spec:
         - command:
             - sh
             - -ec
-            - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount"
-              $CGROUP_ROOT;
-
+            - |
+              cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
               rm /hostbin/cilium-mount
-
-              '
           env:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2

--- a/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
@@ -62,9 +62,10 @@ spec:
     spec:
       containers:
         - args:
-            - "kubectl -n cilium get clusterserviceversion -ojson \\\n  | jq '.items[]\
-              \ | select(.spec.version | test(\"^1.11.5[+]\") | not) | .metadata.name'\
-              \ \\\n  | xargs --no-run-if-empty kubectl -n cilium delete clusterserviceversions\n"
+            - |
+              kubectl -n cilium get clusterserviceversion -ojson \
+                | jq '.items[] | select(.spec.version | test("^1.11.5[+]") | not) | .metadata.name' \
+                | xargs --no-run-if-empty kubectl -n cilium delete clusterserviceversions
           command:
             - sh
             - -c


### PR DESCRIPTION
Some Cilium EE OLM tar-balls have a different directory structure. This PR adjusts the component to be able to handle both structures which we've observed so far. Additionally, an explicit error message is thrown when neither structure is found in the unpacked tar-ball.

This fixes the component for installing Cililum EE OLM 1.11.17 (and possibly other 1.11 patch releases).

Notably the tar-ball for Cilium EE OLM 1.12.6 is using the "old" format again.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
