### PR TITLE
Ignore hidden files when loading OLM manifests

### DIFF
--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -23,7 +23,10 @@ local olmDir =
   else
     error "Unknown release '%s'" % [ params.release ];
 
-local olmFiles = std.map(
+local olmFiles = std.filterMap(
+  function(name)
+    // drop hidden files
+    !std.startsWith(name, '.'),
   function(name) {
     filename: name,
     contents: std.parseJson(kap.yaml_load(olmDir + name)),


### PR DESCRIPTION
Some Cilium EE OLM tar-balls contain hidden files (e.g. 1.12.6), which we're not interested in. Additionally, these files break `kap.yaml_load()` because they don't contain valid YAML.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
