### PR TITLE
Add support for more tarball structures

### DIFF
--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -10,16 +10,31 @@ local olmDir =
   if params.release == 'opensource' then
     prefix + 'cilium-olm-master/manifests/cilium.v%s/' % params.olm.full_version
   else if params.release == 'enterprise' then
-    local newpath = 'tmp/cilium-ee-olm/manifests/';
+    local path_variants = [
+      // Known releases: 1.11.5, 1.12.6
+      '',
+      // Known releases: 1.11.17
+      'tmp/cilium-ee-olm/manifests/',
+      // Known releases: 1.13.2
+      'cilium-ee-olm/manifests/',
+    ];
     local manifests_dir = 'cilium.v%s/' % params.olm.full_version;
-    if kap.file_exists(prefix + manifests_dir).exists then
-      prefix + manifests_dir
-    else if kap.file_exists(prefix + newpath + manifests_dir).exists then
-      prefix + newpath + manifests_dir
-    else
+    local dir = std.foldl(
+      function(curr, variant)
+        local cand = prefix + variant + manifests_dir;
+        if kap.file_exists(cand).exists then
+          cand
+        else
+          curr,
+      path_variants,
+      null
+    );
+    if dir == null then
       error
         'Unable to find manifests path for Cilium EE %s. ' % params.olm.full_version
         + 'Check structure of .tar.gz and update component.'
+    else
+      dir
   else
     error "Unknown release '%s'" % [ params.release ];
 


### PR DESCRIPTION
The Cilium EE 1.13.2 OLM tarball has yet another directory structure. This commit refactors the component to go through a list of possible directories until it finds one that exists for the requested Cilium EE OLM version.

Follow-up for #75 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
