### PR TITLE
Switch to `kubeProxyReplacement: partial`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -24,7 +24,22 @@ parameters:
         operator:
           clusterPoolIPv4MaskSize: "23"
           clusterPoolIPv4PodCIDR: 10.128.0.0/14
-      kubeProxyReplacement: probe
+      kubeProxyReplacement: partial
+      sessionAffinity: true
+      hostServices:
+        enabled: true
+      nodePort:
+        # Explicitly select ensX device as direct routing device for node-port
+        # traffic. If multiple ens* devices are present on a node, the one
+        # with the lowest alphanumerical name is picked.
+        # Adjust this parameter if your nodes don't have host interfaces which
+        # start with ens.
+        directRoutingDevice: ens+
+        enabled: true
+      externalIPs:
+        enabled: true
+      hostPort:
+        enabled: true
       prometheus:
         enabled: true
         serviceMonitor:

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -15,6 +15,7 @@ data:
   cluster-pool-ipv4-mask-size: '23'
   custom-cni-conf: 'false'
   debug: 'false'
+  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   disable-endpoint-crd: 'false'
   enable-auto-protect-node-port-range: 'true'
@@ -22,8 +23,11 @@ data:
   enable-bpf-clock-probe: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
+  enable-external-ips: 'true'
   enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
+  enable-host-port: 'true'
+  enable-host-reachable-services: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-masquerade: 'true'
@@ -33,6 +37,7 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'true'
   enable-local-redirect-policy: 'false'
+  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-session-affinity: 'true'
@@ -45,7 +50,7 @@ data:
   install-iptables-rules: 'true'
   install-no-conntrack-iptables-rules: 'false'
   ipam: cluster-pool
-  kube-proxy-replacement: probe
+  kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ''
   monitor-aggregation: medium
   monitor-aggregation-flags: all

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -15,6 +15,7 @@ data:
   cluster-pool-ipv4-mask-size: '23'
   custom-cni-conf: 'false'
   debug: 'false'
+  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   disable-endpoint-crd: 'false'
   enable-auto-protect-node-port-range: 'true'
@@ -22,8 +23,11 @@ data:
   enable-bpf-clock-probe: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
+  enable-external-ips: 'true'
   enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
+  enable-host-port: 'true'
+  enable-host-reachable-services: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-masquerade: 'true'
@@ -33,6 +37,7 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'true'
   enable-local-redirect-policy: 'false'
+  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-session-affinity: 'true'
@@ -45,7 +50,7 @@ data:
   install-iptables-rules: 'true'
   install-no-conntrack-iptables-rules: 'false'
   ipam: cluster-pool
-  kube-proxy-replacement: probe
+  kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ''
   monitor-aggregation: medium
   monitor-aggregation-flags: all

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -9,6 +9,12 @@ spec:
     confPath: /var/run/multus/cni/net.d
   endpointRoutes:
     enabled: true
+  externalIPs:
+    enabled: true
+  hostPort:
+    enabled: true
+  hostServices:
+    enabled: true
   hubble:
     tls:
       enabled: false
@@ -17,7 +23,10 @@ spec:
     operator:
       clusterPoolIPv4MaskSize: '23'
       clusterPoolIPv4PodCIDR: 10.128.0.0/14
-  kubeProxyReplacement: probe
+  kubeProxyReplacement: partial
+  nodePort:
+    directRoutingDevice: ens+
+    enabled: true
   operator:
     prometheus:
       enabled: false
@@ -34,3 +43,4 @@ spec:
     enabled: true
     serviceMonitor:
       enabled: true
+  sessionAffinity: true


### PR DESCRIPTION
Enable kube-proxy replacement for host, hostPort, nodePort and externalIP services. Additionally, explicitly select `ensX` interface for direct routing for nodePort services and enable session affinity. This config should roughly replicate the config we previously had with `kubeProxyReplacement: probe`.

This is in preparation for Cilium 1.13 which removes `kubeProxyReplacement: probe`.

Factored out from #78 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
