### PR TITLE
Inject K8s service host/port into OLM deployment

### DIFF
--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,6 +52,10 @@ spec:
               value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
             - name: RELATED_IMAGE_CLUSTERMESH_ETCD
               value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
+            - name: KUBERNETES_SERVICE_HOST
+              value: 172.30.0.1
+            - name: KUBERNETES_SERVICE_PORT
+              value: 443
           image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:15f7661886456a7f7277086cb76d056a3e5f13c34a30ee48cabb633afafe0a86
           name: operator
           ports:

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.13.8-xe0355c7-clusterserviceversion.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.13.8-xe0355c7-clusterserviceversion.yaml
@@ -202,6 +202,10 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
+                      - name: KUBERNETES_SERVICE_HOST
+                        value: 172.30.0.1
+                      - name: KUBERNETES_SERVICE_PORT
+                        value: 443
                     image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:15f7661886456a7f7277086cb76d056a3e5f13c34a30ee48cabb633afafe0a86
                     name: operator
                     ports:

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -25,6 +25,8 @@ spec:
     operator:
       clusterPoolIPv4MaskSize: '23'
       clusterPoolIPv4PodCIDR: 10.128.0.0/14
+  k8sServiceHost: 172.30.0.1
+  k8sServicePort: 443
   kubeProxyReplacement: partial
   l7Proxy: true
   nodePort:

--- a/tests/olm-opensource.yml
+++ b/tests/olm-opensource.yml
@@ -2,3 +2,6 @@ parameters:
   cilium:
     install_method: olm
     release: opensource
+    cilium_helm_values:
+      k8sServiceHost: 172.30.0.1
+      k8sServicePort: 443


### PR DESCRIPTION
We set the environment variables in the `cilium-ee-olm-overrides` configmap when deploying Cilium EE via OLM and we patch the OLM deployment when deploying Cilium OSS via OLM.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
