### PR TITLE
Disable NodePort health checks by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -40,6 +40,12 @@ parameters:
         # start with ens.
         directRoutingDevice: ens+
         enabled: true
+        # We need to disable the node-port health check as long as we use
+        # `kubeProxyReplacement=partial`, as kube-proxy also deploys a
+        # health-check endpoint for services with type=LoadBalancer and
+        # externalTrafficPolicy=Local.
+        enableHealthCheck: false
+
       externalIPs:
         enabled: true
       hostPort:

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -29,7 +29,7 @@ data:
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-external-ips: 'true'
-  enable-health-check-nodeport: 'true'
+  enable-health-check-nodeport: 'false'
   enable-health-checking: 'true'
   enable-host-port: 'true'
   enable-hubble: 'true'

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -29,7 +29,7 @@ data:
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-external-ips: 'true'
-  enable-health-check-nodeport: 'true'
+  enable-health-check-nodeport: 'false'
   enable-health-checking: 'true'
   enable-host-port: 'true'
   enable-hubble: 'true'

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -29,7 +29,7 @@ data:
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-external-ips: 'true'
-  enable-health-check-nodeport: 'true'
+  enable-health-check-nodeport: 'false'
   enable-health-checking: 'true'
   enable-host-port: 'true'
   enable-hubble: 'true'

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -31,6 +31,7 @@ spec:
   l7Proxy: true
   nodePort:
     directRoutingDevice: ens+
+    enableHealthCheck: false
     enabled: true
   operator:
     prometheus:


### PR DESCRIPTION
As long as we use `kubeProxyReplacement=partial` as the default, we need to disable NodePort health checks in the defaults, as kube-proxy will also deploy a health-check listener for services with `type=LoadBalancer` and `externalTrafficPolicy=Local`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
