### PR TITLE
Fix Cilium NetworkPolicy rules in aggregated clusterroles

### DIFF
--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -23,7 +23,7 @@ local view = kube.ClusterRole('syn-cilium-view') {
     // ciliumnetworkpolicies and ciliumendpoints are namespace-scoped, so we
     // aggregate them to `view`, `ciliumconfigs` as well, but the operator
     // already creates aggregations for that one.
-    ciliumRule([ 'networkpolicies', 'ciliumendpoints' ]),
+    ciliumRule([ 'ciliumnetworkpolicies', 'ciliumendpoints' ]),
   ],
 };
 
@@ -35,10 +35,9 @@ local edit = kube.ClusterRole('syn-cilium-edit') {
     },
   },
   rules: [
-    // ciliumnetworkpolicies and ciliumendpoints are namespace-scoped, so we
-    // aggregate them to `view`, `ciliumconfigs` as well, but the operator
-    // already creates aggregations for that one.
-    ciliumRule([ 'networkpolicies' ]) {
+    // We aggregate ciliumnetworkpolicies to `edit`, so that users can create
+    // and modify cilium networkpolicies in their namespace.
+    ciliumRule([ 'ciliumnetworkpolicies' ]) {
       verbs: [
         'create',
         'delete',

--- a/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -12,7 +12,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
       - ciliumendpoints
     verbs:
       - get
@@ -32,7 +32,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
     verbs:
       - create
       - delete

--- a/tests/golden/egress-gateway/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -12,7 +12,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
       - ciliumendpoints
     verbs:
       - get
@@ -32,7 +32,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
     verbs:
       - create
       - delete

--- a/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -12,7 +12,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
       - ciliumendpoints
     verbs:
       - get
@@ -32,7 +32,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
     verbs:
       - create
       - delete

--- a/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -12,7 +12,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
       - ciliumendpoints
     verbs:
       - get
@@ -32,7 +32,7 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - networkpolicies
+      - ciliumnetworkpolicies
     verbs:
       - create
       - delete


### PR DESCRIPTION
The correct resource is `ciliumnetworkpolicies` and not `networkpolicies`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
