### PR TITLE
Set `SkipDryRunOnMissingResource=true` on egress gateway policies

### DIFF
--- a/component/egress-gateway-policies.jsonnet
+++ b/component/egress-gateway-policies.jsonnet
@@ -6,7 +6,13 @@ local inv = kap.inventory();
 local params = inv.parameters.cilium;
 
 local CiliumEgressGatewayPolicy(name) =
-  kube._Object('cilium.io/v2', 'CiliumEgressGatewayPolicy', name);
+  kube._Object('cilium.io/v2', 'CiliumEgressGatewayPolicy', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+  };
 
 
 local policies = com.generateResources(

--- a/tests/golden/egress-gateway/cilium/cilium/20_egress_gateway_policies.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/20_egress_gateway_policies.yaml
@@ -1,7 +1,8 @@
 apiVersion: cilium.io/v2
 kind: CiliumEgressGatewayPolicy
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: all-example-namespace
   name: all-example-namespace


### PR DESCRIPTION
The cilium-operator only deploys the custom resource after the feature is enabled. If we try to enable the feature and deploy policies at the same time, the ArgoCD sync will fail unless we tell ArgoCD to skip the dry-run for the policies.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
