### PR TITLE
Add support for configuring OLM operator log level

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -90,6 +90,7 @@ parameters:
         limits:
           cpu: 100m
           memory: 500Mi
+      log_level: info
 
     charts:
       cilium:

--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -70,6 +70,13 @@ local patchManifests = function(file)
             if c.name == 'operator' then
               c {
                 resources+: params.olm.resources,
+                command: [
+                  cmd
+                  for cmd in super.command
+                  if cmd != '--zap-devel'
+                ] + [
+                  '--zap-log-level=%s' % params.olm.log_level,
+                ],
                 env+:
                   if params.release == 'opensource' then
                     (

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -156,6 +156,14 @@ default:: https://github.com/projectsyn/component-cilium/blob/master/class/defau
 
 The resource requests and limits for the Cilium OLM Deployment.
 
+== `olm.log_level`
+
+[horizontal]
+type:: string
+default:: `info`
+
+https://github.com/uber-go/zap[Zap] log level for the OLM operator.
+
 == `cilium_helm_values`
 
 [horizontal]

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -22,9 +22,9 @@ spec:
             - --watches-file=watches.yaml
             - --enable-leader-election
             - --leader-election-id=cilium-olm
-            - --zap-devel
             - --metrics-addr=localhost:8082
             - --health-probe-bind-address=localhost:8081
+            - --zap-log-level=info
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.13.8-xe0355c7-clusterserviceversion.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.13.8-xe0355c7-clusterserviceversion.yaml
@@ -172,9 +172,9 @@ spec:
                       - --watches-file=watches.yaml
                       - --enable-leader-election
                       - --leader-election-id=cilium-olm
-                      - --zap-devel
                       - --metrics-addr=localhost:8082
                       - --health-probe-bind-address=localhost:8081
+                      - --zap-log-level=info
                     env:
                       - name: WATCH_NAMESPACE
                         valueFrom:


### PR DESCRIPTION
The upstream configuration enables `--zap-devel` which enables debug logging. We don't need or want this for production deployments.

This PR introduces a parameter `olm.log_level` which is used to set `--zap-log-level` for the OLM operator.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
