### PR TITLE
Prepare migration to `IsovalentEgressGatewayPolicy` resources

### DIFF
--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -11,6 +11,17 @@ local ciliumRule(resources) =
     ],
   };
 
+local isovalentRule(resources) =
+  {
+    apiGroups: [ 'isovalent.com' ],
+    resources: resources,
+    verbs: [
+      'get',
+      'list',
+      'watch',
+    ],
+  };
+
 local view = kube.ClusterRole('syn-cilium-view') {
   metadata+: {
     labels+: {
@@ -58,8 +69,9 @@ local cluster_reader = kube.ClusterRole('syn-cilium-cluster-reader') {
   rules: [
     // We could explicitly list and maintain cluster-scoped resources here, but
     // that's overhead we don't really need, so we just grant "view" permissions
-    // on all resources in `cilium.io` to `cluster-reader`.
+    // on all resources in `cilium.io` and `isovalent.com` to `cluster-reader`.
     ciliumRule([ '*' ]),
+    isovalentRule([ '*' ]),
   ],
 };
 

--- a/component/egress-gateway-policies.jsonnet
+++ b/component/egress-gateway-policies.jsonnet
@@ -9,7 +9,7 @@ local CiliumEgressGatewayPolicy(name) =
   kube._Object('cilium.io/v2', 'CiliumEgressGatewayPolicy', name) {
     metadata+: {
       annotations+: {
-        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true,Prune=false',
       },
     },
   };

--- a/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -57,3 +57,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/egress-gateway/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -57,3 +57,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/egress-gateway/cilium/cilium/20_egress_gateway_policies.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/20_egress_gateway_policies.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumEgressGatewayPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=false
   labels:
     name: all-example-namespace
   name: all-example-namespace

--- a/tests/golden/egress-gateway/cilium/cilium/20_namespace_egress_ip_policies.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/20_namespace_egress_ip_policies.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumEgressGatewayPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=false
     cilium.syn.tools/debug-interface-index: start=3221226016, end=3221226047, ip=3221226045
     cilium.syn.tools/description: Generated policy to assign egress IP 192.0.2.61
       in egress range "egress_a" (192.0.2.32 - 192.0.2.63) to namespace bar.
@@ -30,7 +30,7 @@ apiVersion: cilium.io/v2
 kind: CiliumEgressGatewayPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=false
     cilium.syn.tools/debug-interface-index: start=3221226048, end=3221226079, ip=3221226077
     cilium.syn.tools/description: Generated policy to assign egress IP 192.0.2.93
       in egress range "egress_c" (192.0.2.64 - 192.0.2.95) to namespace baz.
@@ -58,7 +58,7 @@ apiVersion: cilium.io/v2
 kind: CiliumEgressGatewayPolicy
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,Prune=false
     cilium.syn.tools/debug-interface-index: start=3221226016, end=3221226047, ip=3221226016
     cilium.syn.tools/description: Generated policy to assign egress IP 192.0.2.32
       in egress range "egress_a" (192.0.2.32 - 192.0.2.63) to namespace foo.

--- a/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -57,3 +57,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -57,3 +57,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
We ensure that `CiliumEgressGatewayPolicy` resources aren't pruned automatically, so that we'll be able to migrate to `IsovalentEgressGatewayPolicy` resources without interruptions of egress traffic.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
