### PR TITLE
Create RBAC to grant the OLM operator read-only access to Secrets in `kube-system`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -15,6 +15,14 @@ parameters:
       "False": true
 
     cilium_helm_values:
+      bgpControlPlane:
+        secretNamespace:
+          # Ensure that Cilium's BGP control plane is configured to look for
+          # peering secrets in the same namespace where Cilium is installed.
+          # Without this, it's not possible to enable the BGP control plane
+          # when installing Cilium with OLM without patching the OLM RBAC.
+          # See also https://github.com/projectsyn/component-cilium/pull/117.
+          name: ${cilium:_namespace}
       cni:
         binPath: /var/lib/cni/bin
         confPath: /var/run/multus/cni/net.d

--- a/tests/golden/olm-opensource/cilium/cilium/olm/98_fixup_bgp_controlpane_rbac.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/98_fixup_bgp_controlpane_rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-olm
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -4,6 +4,9 @@ metadata:
   name: cilium
   namespace: cilium
 spec:
+  bgpControlPlane:
+    secretNamespace:
+      name: cilium
   bpf:
     masquerade: false
   cni:


### PR DESCRIPTION
When enabling the BGP control plane feature, the OLM operator needs to create a Role and RoleBinding for read-only access to Secrets in the `kube-system` namespace. In Cilium <= 1.14, there's no way to change the namespace which the OLM operator configures as the source for BGP peering secrets to something other than `kube-system`.

However, if Cilium is installed in a namespace other than `kube-system`, such as `cilium`, the OLM operator doesn't have sufficient permissions to create the required Role and RoleBinding in the `kube-system` namespace.

This commit generates RBAC rules which ensure that the OLM operator can create the required RBAC rules in the kube-system namespace.

See also https://github.com/cilium/cilium/issues/31499

Note that this shouldn't be necessary anymore for Cilium >= 1.15 iff Helm value `bgpControlPlane.secretNamespace.name` is set to the namespace where Cilium is installed. Currently the component will only deploy the additional RBAC for Cilium <= 1.14. Additionally, we already set `bgpControlPlane.secretNamespace.name` to `cilium` in anticipation of 1.15.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
