### PR TITLE
Update component defaults to set `kubeProxyReplacement="true"`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -40,28 +40,7 @@ parameters:
           clusterPoolIPv4MaskSize: "23"
           clusterPoolIPv4PodCIDRList:
             - 10.128.0.0/14
-      kubeProxyReplacement: partial
-      sessionAffinity: true
-      socketLB:
-        enabled: true
-      nodePort:
-        # Explicitly select ensX device as direct routing device for node-port
-        # traffic. If multiple ens* devices are present on a node, the one
-        # with the lowest alphanumerical name is picked.
-        # Adjust this parameter if your nodes don't have host interfaces which
-        # start with ens.
-        directRoutingDevice: ens+
-        enabled: true
-        # We need to disable the node-port health check as long as we use
-        # `kubeProxyReplacement=partial`, as kube-proxy also deploys a
-        # health-check endpoint for services with type=LoadBalancer and
-        # externalTrafficPolicy=Local.
-        enableHealthCheck: false
-
-      externalIPs:
-        enabled: true
-      hostPort:
-        enabled: true
+      kubeProxyReplacement: "true"
       egressGateway:
         enabled: ${cilium:egress_gateway:enabled}
       bpf:

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -5,7 +5,7 @@ data:
   auto-direct-node-routes: 'false'
   bpf-lb-external-clusterip: 'false'
   bpf-lb-map-max: '65536'
-  bpf-lb-sock: 'true'
+  bpf-lb-sock: 'false'
   bpf-map-dynamic-size-ratio: '0.0025'
   bpf-policy-map-max: '16384'
   bpf-root: /sys/fs/bpf
@@ -21,7 +21,6 @@ data:
   custom-cni-conf: 'false'
   debug: 'false'
   debug-verbose: ''
-  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   dnsproxy-enable-transparent-mode: 'true'
   egress-gateway-reconciliation-trigger-interval: 1s
@@ -31,10 +30,8 @@ data:
   enable-bpf-masquerade: 'false'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
-  enable-external-ips: 'true'
-  enable-health-check-nodeport: 'false'
+  enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
-  enable-host-port: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-big-tcp: 'false'
@@ -47,11 +44,9 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'true'
   enable-local-redirect-policy: 'false'
-  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-sctp: 'false'
-  enable-session-affinity: 'true'
   enable-svc-source-range-check: 'true'
   enable-vtep: 'false'
   enable-well-known-identities: 'false'
@@ -68,7 +63,7 @@ data:
   ipam-cilium-node-update-rate: 15s
   k8s-client-burst: '10'
   k8s-client-qps: '5'
-  kube-proxy-replacement: partial
+  kube-proxy-replacement: 'true'
   kube-proxy-replacement-healthz-bind-address: ''
   mesh-auth-enabled: 'true'
   mesh-auth-gc-interval: 5m0s

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -5,7 +5,7 @@ data:
   auto-direct-node-routes: 'false'
   bpf-lb-external-clusterip: 'false'
   bpf-lb-map-max: '65536'
-  bpf-lb-sock: 'true'
+  bpf-lb-sock: 'false'
   bpf-map-dynamic-size-ratio: '0.0025'
   bpf-policy-map-max: '16384'
   bpf-root: /sys/fs/bpf
@@ -21,7 +21,6 @@ data:
   custom-cni-conf: 'false'
   debug: 'false'
   debug-verbose: ''
-  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   dnsproxy-enable-transparent-mode: 'true'
   egress-gateway-reconciliation-trigger-interval: 1s
@@ -31,10 +30,8 @@ data:
   enable-bpf-masquerade: 'false'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
-  enable-external-ips: 'true'
-  enable-health-check-nodeport: 'false'
+  enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
-  enable-host-port: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-big-tcp: 'false'
@@ -47,11 +44,9 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'true'
   enable-local-redirect-policy: 'false'
-  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-sctp: 'false'
-  enable-session-affinity: 'true'
   enable-svc-source-range-check: 'true'
   enable-vtep: 'false'
   enable-well-known-identities: 'false'
@@ -68,7 +63,7 @@ data:
   ipam-cilium-node-update-rate: 15s
   k8s-client-burst: '10'
   k8s-client-qps: '5'
-  kube-proxy-replacement: partial
+  kube-proxy-replacement: 'true'
   kube-proxy-replacement-healthz-bind-address: ''
   mesh-auth-enabled: 'true'
   mesh-auth-gc-interval: 5m0s

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -5,7 +5,7 @@ data:
   auto-direct-node-routes: 'false'
   bpf-lb-external-clusterip: 'false'
   bpf-lb-map-max: '65536'
-  bpf-lb-sock: 'true'
+  bpf-lb-sock: 'false'
   bpf-map-dynamic-size-ratio: '0.0025'
   bpf-policy-map-max: '16384'
   bpf-root: /sys/fs/bpf
@@ -21,7 +21,6 @@ data:
   custom-cni-conf: 'false'
   debug: 'false'
   debug-verbose: ''
-  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   dnsproxy-enable-transparent-mode: 'true'
   egress-gateway-reconciliation-trigger-interval: 1s
@@ -31,10 +30,8 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
-  enable-external-ips: 'true'
-  enable-health-check-nodeport: 'false'
+  enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
-  enable-host-port: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-big-tcp: 'false'
@@ -48,11 +45,9 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'false'
   enable-local-redirect-policy: 'false'
-  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-sctp: 'false'
-  enable-session-affinity: 'true'
   enable-svc-source-range-check: 'true'
   enable-vtep: 'false'
   enable-well-known-identities: 'false'
@@ -69,7 +64,7 @@ data:
   ipam-cilium-node-update-rate: 15s
   k8s-client-burst: '10'
   k8s-client-qps: '5'
-  kube-proxy-replacement: partial
+  kube-proxy-replacement: 'true'
   kube-proxy-replacement-healthz-bind-address: ''
   mesh-auth-enabled: 'true'
   mesh-auth-gc-interval: 5m0s

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -5,7 +5,7 @@ data:
   auto-direct-node-routes: 'false'
   bpf-lb-external-clusterip: 'false'
   bpf-lb-map-max: '65536'
-  bpf-lb-sock: 'true'
+  bpf-lb-sock: 'false'
   bpf-map-dynamic-size-ratio: '0.0025'
   bpf-policy-map-max: '16384'
   bpf-root: /sys/fs/bpf
@@ -21,7 +21,6 @@ data:
   custom-cni-conf: 'false'
   debug: 'false'
   debug-verbose: ''
-  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   dnsproxy-enable-transparent-mode: 'true'
   egress-gateway-reconciliation-trigger-interval: 1s
@@ -31,10 +30,8 @@ data:
   enable-bpf-masquerade: 'false'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
-  enable-external-ips: 'true'
-  enable-health-check-nodeport: 'false'
+  enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
-  enable-host-port: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
   enable-ipv4-big-tcp: 'false'
@@ -47,11 +44,9 @@ data:
   enable-l2-neigh-discovery: 'true'
   enable-l7-proxy: 'true'
   enable-local-redirect-policy: 'false'
-  enable-node-port: 'true'
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-sctp: 'false'
-  enable-session-affinity: 'true'
   enable-svc-source-range-check: 'true'
   enable-vtep: 'false'
   enable-well-known-identities: 'false'
@@ -68,7 +63,7 @@ data:
   ipam-cilium-node-update-rate: 15s
   k8s-client-burst: '10'
   k8s-client-qps: '5'
-  kube-proxy-replacement: partial
+  kube-proxy-replacement: 'true'
   kube-proxy-replacement-healthz-bind-address: ''
   mesh-auth-enabled: 'true'
   mesh-auth-gc-interval: 5m0s

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -5,7 +5,7 @@ data:
   auto-direct-node-routes: 'false'
   bpf-lb-external-clusterip: 'false'
   bpf-lb-map-max: '65536'
-  bpf-lb-sock: 'true'
+  bpf-lb-sock: 'false'
   bpf-map-dynamic-size-ratio: '0.0025'
   bpf-policy-map-max: '16384'
   bpf-root: /sys/fs/bpf
@@ -21,7 +21,6 @@ data:
   custom-cni-conf: 'false'
   debug: 'false'
   debug-verbose: ''
-  direct-routing-device: ens+
   disable-cnp-status-updates: 'true'
   dnsproxy-enable-transparent-mode: 'true'
   egress-gateway-reconciliation-trigger-interval: 1s
@@ -31,7 +30,7 @@ data:
   enable-bpf-masquerade: 'false'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
-  enable-health-check-nodeport: 'false'
+  enable-health-check-nodeport: 'true'
   enable-health-checking: 'true'
   enable-hubble: 'true'
   enable-ipv4: 'true'
@@ -48,7 +47,6 @@ data:
   enable-policy: default
   enable-remote-node-identity: 'true'
   enable-sctp: 'false'
-  enable-session-affinity: 'true'
   enable-svc-source-range-check: 'true'
   enable-vtep: 'false'
   enable-well-known-identities: 'false'

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -17,10 +17,6 @@ spec:
     enabled: false
   endpointRoutes:
     enabled: true
-  externalIPs:
-    enabled: true
-  hostPort:
-    enabled: true
   hubble:
     relay:
       enabled: true
@@ -34,12 +30,8 @@ spec:
         - 10.128.0.0/14
   k8sServiceHost: 172.30.0.1
   k8sServicePort: 443
-  kubeProxyReplacement: partial
+  kubeProxyReplacement: 'true'
   l7Proxy: true
-  nodePort:
-    directRoutingDevice: ens+
-    enableHealthCheck: false
-    enabled: true
   operator:
     prometheus:
       enabled: false
@@ -56,6 +48,3 @@ spec:
     enabled: true
     serviceMonitor:
       enabled: true
-  sessionAffinity: true
-  socketLB:
-    enabled: true


### PR DESCRIPTION
This isn't a breaking change, since our previous `kubeProxyReplacement=partial` configuration was already functionally equivalent to `kubeProxyReplacement="true"/strict`, cf. the note in https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#kube-proxy-hybrid-modes

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
