### PR TITLE
Enable BPF masquerading by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -47,7 +47,7 @@ parameters:
       egressGateway:
         enabled: ${cilium:egress_gateway:enabled}
       bpf:
-        masquerade: ${cilium:egress_gateway:enabled}
+        masquerade: true
       l7Proxy: ${cilium:_egressgw_l7proxy:${cilium:egress_gateway:enabled}}
       prometheus:
         enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -251,6 +251,8 @@ l7Proxy: false
 Notably, the L7 proxy feature is disabled by default when egress gateway policies are enabled.
 This is recommended by the Cilium documentation, see also https://docs.cilium.io/en/{helm-minor-version}/network/egress-gateway/#incompatibility-with-other-features[the upstream documentation].
 
+Additionally, BPF masquerading can't be disabled when the egress gateway feature is enabled.
+
 For Cilium EE, the component uses Helm value `egressGateway.enabled` for Helm value `enterprise.egressGatewayHA.enabled` by default.
 It's possible to override this by explicitly setting `egressGateway.enabled=false` and `enterprise.egressGatewayHA.enabled=true` in the component's `cilium_helm_values`.
 

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -28,7 +28,7 @@ data:
   enable-auto-protect-node-port-range: 'true'
   enable-bgp-control-plane: 'true'
   enable-bpf-clock-probe: 'false'
-  enable-bpf-masquerade: 'false'
+  enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-health-check-loadbalancer-ip: 'false'

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -27,7 +27,7 @@ data:
   enable-auto-protect-node-port-range: 'true'
   enable-bgp-control-plane: 'false'
   enable-bpf-clock-probe: 'false'
-  enable-bpf-masquerade: 'false'
+  enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-health-check-loadbalancer-ip: 'false'

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -27,7 +27,7 @@ data:
   enable-auto-protect-node-port-range: 'true'
   enable-bgp-control-plane: 'false'
   enable-bpf-clock-probe: 'false'
-  enable-bpf-masquerade: 'false'
+  enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-health-check-loadbalancer-ip: 'false'

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -27,7 +27,7 @@ data:
   enable-auto-protect-node-port-range: 'true'
   enable-bgp-control-plane: 'false'
   enable-bpf-clock-probe: 'false'
-  enable-bpf-masquerade: 'false'
+  enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-routes: 'true'
   enable-health-check-loadbalancer-ip: 'false'

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -9,7 +9,7 @@ spec:
     secretNamespace:
       name: cilium
   bpf:
-    masquerade: false
+    masquerade: true
   cni:
     binPath: /var/lib/cni/bin
     confPath: /var/run/multus/cni/net.d


### PR DESCRIPTION
We change the component defaults to enable BPF masquerading. See https://docs.cilium.io/en/stable/network/concepts/masquerading/#ebpf-based for details.

The component will force-enable BPF masquerading if the user has enabled the Egress Gateway (or Egress Gateway HA) feature.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
