### PR TITLE
Allow creating CiliumLoadBalancerIPPool with L2 Announcements

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -95,6 +95,7 @@ parameters:
     l2_announcements:
       enabled: false
       policies: {}
+      loadbalancer_ip_pools: {}
 
     bgp:
       enabled: false

--- a/component/l2-announcement-policies.jsonnet
+++ b/component/l2-announcement-policies.jsonnet
@@ -2,6 +2,8 @@ local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 
+local util = import 'util.libsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.cilium;
 
@@ -19,7 +21,11 @@ local policies = com.generateResources(
   CiliumL2AnnouncementPolicy
 );
 
+local lb_ip_pools = util.ipPool(params.l2_announcements.loadbalancer_ip_pools);
+
 {
   [if params.l2_announcements.enabled && std.length(params.l2_announcements.policies) > 0 then
     '50_l2_announcement_policies']: policies,
+  [if params.l2_announcements.enabled && std.length(lb_ip_pools) > 0 then
+    '50_loadbalancer_ip_pools']: lb_ip_pools,
 }

--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -245,8 +245,6 @@ local kubeSystemSecretRO = [
   },
 ];
 
-local olm_version = util.parse_version(params.olm.full_version);
-
 std.foldl(
   function(files, file) files { [std.strReplace(file.filename, '.yaml', '')]: file.contents },
   std.filter(
@@ -254,7 +252,7 @@ std.foldl(
     std.map(function(obj) patchManifests(obj, olmFiles.has_csv), olmFiles.files),
   ),
   {
-    [if olm_version.minor <= 14 then '98_fixup_bgp_controlpane_rbac']: kubeSystemSecretRO,
+    [if util.version.minor <= 14 then '98_fixup_bgp_controlpane_rbac']: kubeSystemSecretRO,
     '99_cleanup': (import 'cleanup.libsonnet'),
   }
 )

--- a/component/util.libsonnet
+++ b/component/util.libsonnet
@@ -1,7 +1,12 @@
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
 
 local inv = kap.inventory();
+local params = inv.parameters.cilium;
 local isOpenshift = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
+
+// Parse cilium version
 
 local parse_version(ver) =
   local verparts = std.split(ver, '.');
@@ -20,7 +25,45 @@ local parse_version(ver) =
     minor: parseOrError(verparts[1], 'minor'),
   };
 
+local version = parse_version(
+  if params.install_method == 'helm' then
+    local chart = if params.release == 'opensource'
+    then
+      'cilium'
+    else
+      'cilium-enterprise';
+    params.charts[chart].version
+  else
+    params.olm.full_version
+);
+
+// CiliumLoadBalancerIPPool
+
+local CiliumLoadBalancerIPPool(name) =
+  kube._Object('cilium.io/v2alpha1', 'CiliumLoadBalancerIPPool', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+  };
+
+local render_ip_pool(name, pool) =
+  {
+    spec: {
+      [if version.minor <= 14 then 'cidrs' else 'blocks']:
+        std.objectValues(pool.blocks),
+      serviceSelector: std.get(pool, 'serviceSelector', {}),
+    } + com.makeMergeable(std.get(pool, 'spec', {})),
+  };
+
+local lb_ip_pools(pools) = com.generateResources(
+  std.mapWithKey(render_ip_pool, pools),
+  CiliumLoadBalancerIPPool,
+);
+
 {
   isOpenshift: isOpenshift,
-  parse_version: parse_version,
+  version: version,
+  ipPool: lb_ip_pools,
 }

--- a/component/util.libsonnet
+++ b/component/util.libsonnet
@@ -57,7 +57,7 @@ local render_ip_pool(name, pool) =
     } + com.makeMergeable(std.get(pool, 'spec', {})),
   };
 
-local lb_ip_pools(pools) = com.generateResources(
+local render_ip_pools(pools) = com.generateResources(
   std.mapWithKey(render_ip_pool, pools),
   CiliumLoadBalancerIPPool,
 );
@@ -65,5 +65,5 @@ local lb_ip_pools(pools) = com.generateResources(
 {
   isOpenshift: isOpenshift,
   version: version,
-  ipPool: lb_ip_pools,
+  ipPool: render_ip_pools,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -623,6 +623,15 @@ l2_announcements:
         loadBalancerIPs: true
 ----
 
+=== `l2_announcements.loadbalancer_ip_pools`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+See xref:references/parameters.adoc#_bgp_loadbalancer_ip_pools[BGP LB IP Pool configuration].
+
+
 == `bgp`
 
 This section allows users to configure the https://docs.cilium.io/en/stable/network/bgp-control-plane/[Cilium BGP control plane].

--- a/tests/golden/l2-announcement/cilium/cilium/50_loadbalancer_ip_pools.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/50_loadbalancer_ip_pools.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  blocks:
+    - cidr: 198.51.100.32/27
+    - start: 203.0.113.10
+      stop: 203.0.113.20
+  serviceSelector:
+    matchLabels:
+      syn.tools/load-balancer-class: cilium

--- a/tests/l2-announcement.yml
+++ b/tests/l2-announcement.yml
@@ -21,3 +21,14 @@ parameters:
               - ^eth[0-9]+
             externalIPs: true
             loadBalancerIPs: true
+      loadbalancer_ip_pools:
+        lb-services:
+          blocks:
+            tn2:
+              cidr: 198.51.100.32/27
+            tn3:
+              start: 203.0.113.10
+              stop: 203.0.113.20
+          serviceSelector:
+            matchLabels:
+              syn.tools/load-balancer-class: cilium


### PR DESCRIPTION
Moves the LB IP Pool generating code to a utility class and allow defining LB IP Pools in L2 Announcements config as well.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
