### PR TITLE
Fix bootstrapping issue in PreSync hook

### DIFF
--- a/component/cleanup.libsonnet
+++ b/component/cleanup.libsonnet
@@ -7,7 +7,12 @@ local name = 'cleanup-old-clusterserviceversions';
 local namespace = params._namespace;
 
 local role = kube.Role(name) {
-  metadata+: { namespace: namespace },
+  metadata+: {
+    namespace: namespace,
+    annotations+: {
+      'argocd.argoproj.io/hook': 'PreSync',
+    },
+  },
   rules: [
     {
       apiGroups: [ 'operators.coreos.com' ],
@@ -27,7 +32,12 @@ local serviceAccount = kube.ServiceAccount(name) {
 };
 
 local roleBinding = kube.RoleBinding(name) {
-  metadata+: { namespace: namespace },
+  metadata+: {
+    namespace: namespace,
+    annotations+: {
+      'argocd.argoproj.io/hook': 'PreSync',
+    },
+  },
   subjects_: [ serviceAccount ],
   roleRef_: role,
 };

--- a/component/cleanup.libsonnet
+++ b/component/cleanup.libsonnet
@@ -18,7 +18,12 @@ local role = kube.Role(name) {
 };
 
 local serviceAccount = kube.ServiceAccount(name) {
-  metadata+: { namespace: namespace },
+  metadata+: {
+    namespace: namespace,
+    annotations+: {
+      'argocd.argoproj.io/hook': 'PreSync',
+    },
+  },
 };
 
 local roleBinding = kube.RoleBinding(name) {

--- a/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
@@ -19,7 +19,8 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
   labels:
     name: cleanup-old-clusterserviceversions
   name: cleanup-old-clusterserviceversions

--- a/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/99_cleanup.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
   labels:
     name: cleanup-old-clusterserviceversions
   name: cleanup-old-clusterserviceversions
@@ -29,7 +30,8 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
   labels:
     name: cleanup-old-clusterserviceversions
   name: cleanup-old-clusterserviceversions


### PR DESCRIPTION
By turning the required SA into a PreSync hook, it gets created before the job which uses it.

Tested on the new cluster by deleting the service account and then syncing.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
