### PR TITLE
Patch OLM RBAC to allow deploying Hubble certgen cronjob

### DIFF
--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
@@ -43,3 +43,28 @@ rules:
       - update
       - list
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - hubble-server-certs
+      - hubble-relay-client-certs
+      - hubble-relay-server-certs
+    resources:
+      - secrets
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cilium-ca
+    resources:
+      - secrets
+    verbs:
+      - get
+      - update


### PR DESCRIPTION
The Cilium Helm chart for cilium <= 1.15 uses a ClusterRole and ClusterRoleBinding for the Hubble certgen CronJob. This is changed to a Role and RoleBinding for the Cilium 1.16 Helm chart.

The OLM operator doesn't have permissions to create the ClusterRole and ClusterRoleBinding out of the box, so we patch the OLM operator ClusterRole to contain the rules that need to be created for the certgen CronJob.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
