### PR TITLE
Grant OLM operator permissions to manage cert-manager certificates

### DIFF
--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -213,6 +213,24 @@ local patchManifests = function(file, has_csv)
           else
             r
           for r in super.rules
+        ] + [
+          // Grant OLM operator permission to manage cert-manager certificate
+          // resources. This is required when setting `method: certmanager`
+          // for some Cilium TLS configuration (e.g. Hubble TLS).
+          {
+            apiGroups: [ 'cert-manager.io' ],
+            resources: [ 'certificates' ],
+            verbs: [
+              'create',
+              'delete',
+              'deletecollection',
+              'get',
+              'list',
+              'patch',
+              'update',
+              'watch',
+            ],
+          },
         ],
       },
     }

--- a/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
+++ b/tests/golden/olm-opensource/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
@@ -65,3 +65,16 @@ rules:
       - servicemonitors
     verbs:
       - '*'
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
This is required when setting `method: certmanager` for some Cilium TLS configuration (e.g. Hubble TLS).




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
