### PR TITLE
Implement initial alert for Cilium Clustermesh

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "Cilium",
       "slug": "cilium",
       "parameter_key": "cilium",
-      "test_cases": "defaults helm-opensource olm-opensource egress-gateway bgp-control-plane kubeproxyreplacement-strict l2-announcement",
+      "test_cases": "defaults helm-opensource olm-opensource egress-gateway bgp-control-plane kubeproxyreplacement-strict l2-announcement clustermesh",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -24,7 +24,8 @@
       "github_owner": "projectsyn",
       "github_name": "component-cilium",
       "github_url": "https://github.com/projectsyn/component-cilium",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
           - bgp-control-plane
           - kubeproxyreplacement-strict
           - l2-announcement
+          - clustermesh
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -60,6 +61,7 @@ jobs:
           - bgp-control-plane
           - kubeproxyreplacement-strict
           - l2-announcement
+          - clustermesh
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/helm-opensource.yml tests/olm-opensource.yml tests/egress-gateway.yml tests/bgp-control-plane.yml tests/kubeproxyreplacement-strict.yml tests/l2-announcement.yml
+test_instances = tests/defaults.yml tests/helm-opensource.yml tests/olm-opensource.yml tests/egress-gateway.yml tests/bgp-control-plane.yml tests/kubeproxyreplacement-strict.yml tests/l2-announcement.yml tests/clustermesh.yml

--- a/class/cilium.yml
+++ b/class/cilium.yml
@@ -4,6 +4,12 @@ parameters:
     opensource: cilium
     enterprise: cilium-enterprise
   =_kapitan:
+    jsonnet_input_paths:
+      - ${_base_directory}/component/aggregated-clusterroles.jsonnet
+      - ${_base_directory}/component/egress-gateway-policies.jsonnet
+      - ${_base_directory}/component/l2-announcement-policies.jsonnet
+      - ${_base_directory}/component/bgp-control-plane.jsonnet
+      - ${_base_directory}/component/ocp-manage-kube-proxy.jsonnet
     olm:
       dependencies:
         - type: https
@@ -22,12 +28,7 @@ parameters:
           input_type: jsonnet
           output_path: ${_instance}/olm/
 
-        - input_paths:
-            - ${_base_directory}/component/aggregated-clusterroles.jsonnet
-            - ${_base_directory}/component/egress-gateway-policies.jsonnet
-            - ${_base_directory}/component/l2-announcement-policies.jsonnet
-            - ${_base_directory}/component/bgp-control-plane.jsonnet
-            - ${_base_directory}/component/ocp-manage-kube-proxy.jsonnet
+        - input_paths: ${_kapitan:jsonnet_input_paths}
           input_type: jsonnet
           output_path: ${_instance}/
 
@@ -49,12 +50,7 @@ parameters:
             - ${_base_directory}/component/helm-namespace.jsonnet
           input_type: jsonnet
           output_path: ${_instance}/01_cilium_helmchart
-        - input_paths:
-            - ${_base_directory}/component/aggregated-clusterroles.jsonnet
-            - ${_base_directory}/component/egress-gateway-policies.jsonnet
-            - ${_base_directory}/component/l2-announcement-policies.jsonnet
-            - ${_base_directory}/component/bgp-control-plane.jsonnet
-            - ${_base_directory}/component/ocp-manage-kube-proxy.jsonnet
+        - input_paths: ${_kapitan:jsonnet_input_paths}
           input_type: jsonnet
           output_path: ${_instance}/
         - input_paths:

--- a/class/cilium.yml
+++ b/class/cilium.yml
@@ -10,6 +10,7 @@ parameters:
       - ${_base_directory}/component/l2-announcement-policies.jsonnet
       - ${_base_directory}/component/bgp-control-plane.jsonnet
       - ${_base_directory}/component/ocp-manage-kube-proxy.jsonnet
+      - ${_base_directory}/component/alerts.jsonnet
     olm:
       dependencies:
         - type: https

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -107,6 +107,11 @@ parameters:
       peerings: {}
       loadbalancer_ip_pools: {}
 
+    alerts:
+      ignoreNames: []
+      patches: {}
+      additionalRules: {}
+
     olm:
       source:
         opensource: https://github.com/isovalent/olm-for-cilium/archive/main.tar.gz

--- a/component/alerts.jsonnet
+++ b/component/alerts.jsonnet
@@ -1,9 +1,12 @@
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local prom = import 'lib/prom.libsonnet';
 local util = import 'util.libsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.cilium;
+
+local ignoreNames = com.renderArray(params.alerts.ignoreNames);
 
 local clustermesh_enabled =
   std.get(params.cilium_helm_values, 'clustermesh', { config: { enabled: false } }).config.enabled;
@@ -12,7 +15,7 @@ local alertpatching = if util.isOpenshift then
   import 'lib/alert-patching.libsonnet'
 else
   {
-    filterPatchRules(g, patchNames): g,
+    filterPatchRules(g, ignoreNames, patches, preserveRecordingRules, patchNames): g,
   };
 
 local clustermesh_group = {
@@ -43,7 +46,45 @@ local clustermesh_group = {
 local clustermesh_alerts = prom.PrometheusRule('cilium-clustermesh') {
   spec+: {
     groups: [
-      alertpatching.filterPatchRules(clustermesh_group, patchNames=false),
+      alertpatching.filterPatchRules(
+        clustermesh_group,
+        ignoreNames=ignoreNames,
+        patches=params.alerts.patches,
+        preserveRecordingRules=true,
+        patchNames=false,
+      ),
+    ],
+  },
+};
+
+local additional_group =
+  local parseRuleName(rname) =
+    local rparts = std.splitLimit(rname, ':', 1);
+    assert
+      std.length(rparts) == 2 :
+      'Expected custom alert rule to be prefixed with `record:` or `alert:`.';
+    assert
+      std.member([ 'alert', 'record' ], rparts[0]) :
+      'Expected custom alert rule to be prefixed with `record:` or `alert:`, got `%s:`.' % rparts[0];
+    { [rparts[0]]: rparts[1] };
+  {
+    name: 'cilium-user.rules',
+    rules: [
+      params.alerts.additionalRules[rname] + parseRuleName(rname)
+      for rname in std.objectFields(params.alerts.additionalRules)
+    ],
+  };
+
+local additional_alerts = prom.PrometheusRule('cilium-custom') {
+  spec+: {
+    groups: [
+      alertpatching.filterPatchRules(
+        additional_group,
+        ignoreNames=ignoreNames,
+        patches=params.alerts.patches,
+        preserveRecordingRules=true,
+        patchNames=false,
+      ),
     ],
   },
 };
@@ -51,4 +92,6 @@ local clustermesh_alerts = prom.PrometheusRule('cilium-clustermesh') {
 {
   [if clustermesh_enabled && std.length(clustermesh_group.rules) > 0 then
     '10_clustermesh_alerts']: clustermesh_alerts,
+  [if std.length(additional_group.rules) > 0 then
+    '10_custom_alerts']: additional_alerts,
 }

--- a/component/alerts.jsonnet
+++ b/component/alerts.jsonnet
@@ -1,0 +1,54 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local prom = import 'lib/prom.libsonnet';
+local util = import 'util.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.cilium;
+
+local clustermesh_enabled =
+  std.get(params.cilium_helm_values, 'clustermesh', { config: { enabled: false } }).config.enabled;
+
+local alertpatching = if util.isOpenshift then
+  import 'lib/alert-patching.libsonnet'
+else
+  {
+    filterPatchRules(g, patchNames): g,
+  };
+
+local clustermesh_group = {
+  name: 'cilium-clustermesh.rules',
+  rules: [
+    {
+      local this = self,
+      alert: 'CiliumClustermeshRemoteClusterNotReady',
+      expr: 'cilium_clustermesh_remote_cluster_readiness_status == 0',
+      'for': '10m',
+      labels: {
+        severity: 'critical',
+      },
+      annotations: {
+        runbook_url:
+          'https://hub.syn.tools/cilium/runbooks/CiliumClustermeshRemoteClusterNotReady.html',
+        message: 'Remote cluster ${{ labels.target_cluster }} not reachable from ${{ labels.source_node_name }}',
+        description: |||
+          Remote cluster ${{ labels.target_cluster }} has been unreachable from
+          ${{ labels.source_node_name }} on cluster ${{ labels.source_cluster }} for the
+          last %s.
+        ||| % this['for'],
+      },
+    },
+  ],
+};
+
+local clustermesh_alerts = prom.PrometheusRule('cilium-clustermesh') {
+  spec+: {
+    groups: [
+      alertpatching.filterPatchRules(clustermesh_group, patchNames=false),
+    ],
+  },
+};
+
+{
+  [if clustermesh_enabled && std.length(clustermesh_group.rules) > 0 then
+    '10_clustermesh_alerts']: clustermesh_alerts,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -712,6 +712,46 @@ Make sure to check the upstream documentation for the version of Cilium that you
 The LoadBalancer IP address management (LB IPAM) feature is under active development and sometimes has significant changes between Cilium minor versions.
 ====
 
+== `alerts`
+
+This section allows users to configure alerts for Cilium.
+The component expects that an externally-managed Prometheus stack is running on the target cluster.
+For OpenShift 4, the component makes use of the component libraries provided by https://github.com/appuio/component-openshift4-monitoring.git[component `openshift4-monitoring`].
+On other distributions, the component expects that a component library `prom.libsonnet` is available, for example via https://github.com/projectsyn/component-prometheus.git[component `prometheus`].
+
+=== `alerts.ignoreNames`
+
+[horizontal]
+type:: list
+default:: `[]`
+
+Alerts which shouldn't be deployed.
+The list supports removal of entries by prefixing them with `~`.
+
+=== `alerts.patches`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Patches for alerts managed by the component.
+The component expects that keys in this object match the name of an alert managed through the component.
+The value of each entry is expected to be a valid partial Prometheus rule definition.
+
+=== `alerts.additionalRules`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+This parameter allows users to configure additional Prometheus recording and alerting rules.
+The component expects that keys of this object are prefixed with either `alert:` or `record:` and will use these prefixes to create alerting or recording rules.
+The component will take the suffix of the key as the alerting or recording rule name and will set field `alert` or `record` of the rule to the suffix.
+The value of each entry will be used as the base Prometheus rule in which the `alert` or `record` field will be injected.
+
+NOTE: Parameters `alerts.ignoreNames` and `alerts.patches` are also applied to alerts defined through this parameter.
+
+
 == Example
 
 [source,yaml]

--- a/docs/modules/ROOT/pages/runbooks/CiliumClustermeshRemoteClusterNotReady.adoc
+++ b/docs/modules/ROOT/pages/runbooks/CiliumClustermeshRemoteClusterNotReady.adoc
@@ -1,0 +1,127 @@
+= CiliumClustermeshRemoteClusterNotReady
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires if a remote cluster is not reachable from a node for 10 minutes or longer.
+This usually indicates one of the following two:
+
+. A local issue on the node prevents the Cilium agent to connect to the remote cluster or the cluster mesh API server
+. The remote cluster's cluster mesh API server is not available
+. There are network issues preventing cluster mesh connectivity
+
+TIP: Depending on the network configuration, there may be static routes on each node for the remote cluster's cluster mesh API server.
+
+NOTE: When using KVStoreMesh, the agents on the cluster connect to the *local* cache of the remote cluster mesh API server.
+
+== icon:bug[] Steps for debugging
+
+NOTE: The steps in this section assume that your current Kubernetes context points to the source cluster.
+
+TIP: This section assumes that you're running cluster mesh with the cluster mesh API server enabled.
+
+=== Prerequisites
+
+* `cilium` CLI, install from https://github.com/cilium/cilium-cli[icon:github[] cilium/cilium-cli]
+
+=== Identifying the root cause
+
+First, check the source cluster's overall cluster mesh status
+
+[source,bash]
+----
+cilium -n cilium clustermesh status --as=cluster-admin <1>
+----
+<1> `--as=cluster-admin` is required on VSHN Managed OpenShift, may need to be left out on other clusters.
+
+If the output indicates that all nodes are unable to connect to the remote cluster's clustermesh API, it's likely that the issue is either on the remote cluster, or in the network between the clusters.
+
+If the output indicates that only a few source nodes are affected, it's likely that the issue is in the Cilium agent or the routing configuration of the nodes.
+
+=== Investigating cluster mesh API
+
+The cluster mesh API runs in the `cilium` namespace as deployment `clustermesh-apiserver`.
+Check that the pod runs and check the logs for errors with
+
+[source,bash]
+----
+kubectl -n cilium get pods -l app.kubernetes.io/name=clustermesh-apiserver
+kubectl -n cilium logs deploy/clustermesh-apiserver --all-containers
+----
+
+=== Checking connectivity from a Cilium agent pod
+
+If the `cilium clustermesh status` output indicates that only a few nodes are affected, you can run a more detailed check from the nodes' agent pods.
+In the output of these command, you should see whether the agent can connect to the cluster mesh API and whether the clustermesh certificates are still valid.
+
+[source,bash]
+----
+NODE=<node name of affected node> <1>
+AGENT_POD=$(kubectl -n cilium get pods --field-selector=spec.nodeName=$NODE \
+  -l app.kubernetes.io/name=cilium-agent -oname)
+
+kubectl -n cilium exec -it $AGENT_POD --as=cluster-admin -- cilium status <2>
+kubectl -n cilium exec -it $AGENT_POD --as=cluster-admin -- cilium troubleshoot clustermesh <3>
+----
+<1> Set this to the name of an affected node's `Node` object
+<2> Show a summary of the Cilium agent status.
+You should see in the output of this command whether the agent can't reach one or more of the remote cluster's nodes.
+<3> This command will show connection details to the remote cluster's cluster mesh API server or the local cache in case you're using KVStoreMesh.
+
+TIP: `--as=cluster-admin` may need to be left out on some clusters.
+
+If the output of `cilium troubleshoot clustermesh` refers to the local cluster's cluster mesh API server, it's likely that you're using KVStoreMesh.
+In that case you can check the KVStoreMesh connection to the remote cluster mesh API server in the `clustermesh-apiserver` deployment:
+
+[source,bash]
+----
+kubectl -n cilium --as=cluster-admin exec -it deploy/clustermesh-apiserver -c kvstoremesh -- \
+   clustermesh-apiserver kvstoremesh-dbg status <1>
+
+kubectl exec -it -n cilium --as=cluster-admin deploy/clustermesh-apiserver -c kvstoremesh -- \
+  clustermesh-apiserver kvstoremesh-dbg troubleshoot <2>
+----
+<1> Show a connection summary of the KVStoreMesh
+<2> Show connection details of the KVStoreMesh
+
+You can also run `cilium-health status --probe` in the agent pod to actively probe the node to node connectivity:
+
+[source,bash]
+----
+kubectl -n cilium exec -it $AGENT_POD --as=cluster-admin -- cilium-health status --probe
+----
+
+=== Checking node routing tables and connectivity
+
+For setups which use static routes to make the nodes of the clusters participating in the cluster mesh reachable from each other, you can check the routing tables on the host and verify connectivity with `ping`.
+
+.OpenShift 4
+[source,bash]
+----
+NODE=<node name of affected node>
+REMOTE_NODE=<ip of a node in the remote cluster>
+oc -n syn-debug-nodes debug node/${NODE} --as=cluster-admin -- chroot /host ip r
+oc -n syn-debug-nodes debug node/${NODE} --as=cluster-admin -- chroot /host ping -c4 ${REMOTE_NODE}
+----
+
+.Other K8s
+[source,bash]
+----
+DEBUG_IMAGE=ghcr.io/digitalocean-packages/doks-debug:latest <1>
+NODE=<node name of affected node>
+REMOTE_NODE=<ip of a node in the remote cluster>
+kubectl debug node/${NODE} -it --image=${DEBUG_IMAGE} -- ip r
+kubectl debug node/${NODE} -it --image=${DEBUG_IMAGE} -- ping -c4 ${REMOTE_NODE} <2>
+----
+<1> We're using the DigitalOcean `doks-debug` image, which comes with a bunch of common tools installed.
+See https://github.com/digitalocean/doks-debug[icon:github[] digitalocean/doks-debug] for details.
+<2> This command hasn't been tested yet, it's possible that your cluster configuration will not allow `ping` in node debug containers.
+
+== icon:book[] Upstream documentation
+
+* https://docs.cilium.io/en/latest/network/clustermesh/intro/[Cilium OSS --  Cluster Mesh documetation]
+* https://docs.isovalent.com/configuration-guide/cluster-mesh/troubleshooting.html[Cilium OSS --  Cluster Mesh Troubleshooting]
+* https://docs.cilium.io/en/stable/operations/troubleshooting/#troubleshooting-clustermesh[Cilium OSS -- Troubleshooting Cluster Mesh]
+* https://docs.isovalent.com/configuration-guide/cluster-mesh/operating.html[Cilium Enterprise -- Operating Cluster Mesh]
+* https://docs.isovalent.com/configuration-guide/cluster-mesh/troubleshooting.html[Cilium Enterprise -- Troubleshooting Cluster Mesh]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -6,3 +6,7 @@
 * xref:how-tos/upgrade-cilium-enterprise.adoc[Upgrade Cilium Enterprise]
 * OpenShift 4
 ** xref:how-tos/openshift4/upgrade-cilium-oss-to-cilium-enterprise.adoc[Upgrade Cilium OSS to Cilium Enterprise]
+
+.Runbooks
+
+* xref:runbooks/CiliumClustermeshRemoteClusterNotReady.adoc[]

--- a/jsonnetfile.jsonnet
+++ b/jsonnetfile.jsonnet
@@ -1,0 +1,15 @@
+{
+  version: 1,
+  dependencies: [
+    {
+      source: {
+        git: {
+          remote: 'https://github.com/projectsyn/jsonnet-libs',
+          subdir: '',
+        },
+      },
+      version: 'main',
+      name: 'syn',
+    },
+  ],
+}

--- a/tests/clustermesh.yml
+++ b/tests/clustermesh.yml
@@ -1,0 +1,35 @@
+# Overwrite parameters here
+
+parameters:
+  facts:
+    distribution: openshift4
+
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.2.1/lib/patch-operator.libsonnet
+        output_path: vendor/lib/patch-operator.libsonnet
+
+  patch_operator:
+    patch_serviceaccount:
+      name: patch-sa
+    namespace: syn-patch-operator
+
+  cilium:
+    install_method: olm
+    cilium_helm_values:
+      clustermesh:
+        config:
+          enabled: true
+        clusters:
+          - name: c-other-cluster-1234
+            ips:
+              - 198.51.100.20
+            port: 2379
+        useAPIServer: true
+        apiserver:
+          service:
+            type: LoadBalancer
+            loadBalancerClass: io.cilium/l2-announcer
+            annotations:
+              lbipam.cilium.io/ips: 192.0.2.20

--- a/tests/clustermesh.yml
+++ b/tests/clustermesh.yml
@@ -9,6 +9,12 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.2.1/lib/patch-operator.libsonnet
         output_path: vendor/lib/patch-operator.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.11.3/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.11.3/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
   patch_operator:
     patch_serviceaccount:

--- a/tests/clustermesh.yml
+++ b/tests/clustermesh.yml
@@ -39,3 +39,9 @@ parameters:
             loadBalancerClass: io.cilium/l2-announcer
             annotations:
               lbipam.cilium.io/ips: 192.0.2.20
+    alerts:
+      additionalRules:
+        alert:FooTesting:
+          expr: vector(1)
+          annotations:
+            summary: footest

--- a/tests/golden/clustermesh/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-cilium-view
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumendpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn-cilium-edit
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-cilium-cluster-reader
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/clustermesh/cilium/cilium/10_clustermesh_alerts.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/10_clustermesh_alerts.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-clustermesh
+  name: cilium-clustermesh
+spec:
+  groups:
+    - name: cilium-clustermesh.rules
+      rules:
+        - alert: CiliumClustermeshRemoteClusterNotReady
+          annotations:
+            description: |
+              Remote cluster ${{ labels.target_cluster }} has been unreachable from
+              ${{ labels.source_node_name }} on cluster ${{ labels.source_cluster }} for the
+              last 10m.
+            message: Remote cluster ${{ labels.target_cluster }} not reachable from
+              ${{ labels.source_node_name }}
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumClustermeshRemoteClusterNotReady.html
+          expr: cilium_clustermesh_remote_cluster_readiness_status == 0
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: cilium

--- a/tests/golden/clustermesh/cilium/cilium/10_custom_alerts.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/10_custom_alerts.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-custom
+  name: cilium-custom
+spec:
+  groups:
+    - name: cilium-user.rules
+      rules:
+        - alert: FooTesting
+          annotations:
+            summary: footest
+          expr: vector(1)
+          labels:
+            syn: 'true'
+            syn_component: cilium

--- a/tests/golden/clustermesh/cilium/cilium/99_networkoperator_kube_proxy_patch.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/99_networkoperator_kube_proxy_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: network-cluster-72f42451a05fa70
+  name: network-cluster-72f42451a05fa70
+  namespace: syn-patch-operator
+spec:
+  patches:
+    network-cluster-72f42451a05fa70-patch:
+      patchTemplate: |-
+        "spec":
+          "deployKubeProxy": false
+      patchType: application/merge-patch+json
+      targetObjectRef:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+  serviceAccountRef:
+    name: patch-sa

--- a/tests/golden/clustermesh/cilium/cilium/olm/99_cleanup.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/99_cleanup.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cleanup-old-clusterserviceversions
+subjects:
+  - kind: ServiceAccount
+    name: cleanup-old-clusterserviceversions
+    namespace: cilium
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: cleanup-old-clusterserviceversions
+    spec:
+      containers:
+        - args:
+            - |
+              kubectl -n cilium get clusterserviceversion -ojson \
+                | jq '.items[] | select(.spec.version | test("^1.15.1[+]") | not) | .metadata.name' \
+                | xargs --no-run-if-empty kubectl -n cilium delete clusterserviceversions
+          command:
+            - sh
+            - -c
+          env:
+            - name: HOME
+              value: /home
+          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          imagePullPolicy: IfNotPresent
+          name: cleanup-old-clusterserviceversions
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /home
+              name: home
+          workingDir: /home
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: cleanup-old-clusterserviceversions
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: home

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-03-cilium-ciliumconfigs-crd.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-03-cilium-ciliumconfigs-crd.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumconfigs.cilium.io
+spec:
+  group: cilium.io
+  names:
+    kind: CiliumConfig
+    listKind: CiliumConfigList
+    plural: ciliumconfigs
+    singular: ciliumconfig
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the CiliumConfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of CiliumConfig
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status defines the observed state of CiliumConfig
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00000-cilium-namespace.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00000-cilium-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: cilium
+    openshift.io/cluster-logging: 'true'
+    openshift.io/cluster-monitoring: 'true'
+    openshift.io/run-level: '0'
+  name: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00001-cilium-olm-serviceaccount.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00001-cilium-olm-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cilium-olm
+  template:
+    metadata:
+      labels:
+        name: cilium-olm
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/helm-operator
+            - run
+            - --watches-file=watches.yaml
+            - --enable-leader-election
+            - --leader-election-id=cilium-olm
+            - --metrics-addr=localhost:8082
+            - --health-probe-bind-address=localhost:8081
+            - --zap-log-level=info
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RELATED_IMAGE_CILIUM
+              value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+            - name: RELATED_IMAGE_HUBBLE_RELAY
+              value: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+            - name: RELATED_IMAGE_CILIUM_OPERATOR
+              value: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+            - name: RELATED_IMAGE_PREFLIGHT
+              value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+            - name: RELATED_IMAGE_CLUSTERMESH
+              value: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+            - name: RELATED_IMAGE_CERTGEN
+              value: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+            - name: RELATED_IMAGE_HUBBLE_UI_BE
+              value: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+            - name: RELATED_IMAGE_HUBBLE_UI_FE
+              value: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+            - name: RELATED_IMAGE_ETCD_OPERATOR
+              value: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+            - name: RELATED_IMAGE_NODEINIT
+              value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:9ab6be29447125e886300e9258b9a06bedf0a9d87405832aa8b6565ed1ba4215
+          name: operator
+          ports:
+            - containerPort: 9443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 250Mi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      hostNetwork: true
+      serviceAccount: cilium-olm
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      volumes:
+        - emptyDir: {}
+          name: tmp

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00003-cilium-olm-service.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00003-cilium-olm-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443
+  selector:
+    name: cilium-olm

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00004-cilium-olm-leader-election-role.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00004-cilium-olm-leader-election-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-olm-leader-election
+  namespace: cilium
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-olm
+  namespace: cilium
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumconfigs
+      - ciliumconfigs/status
+    verbs:
+      - list
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumconfigs
+      - ciliumconfigs/status
+      - ciliumconfigs/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+      - watch
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - '*'
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00006-leader-election-rolebinding.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00006-leader-election-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00007-cilium-olm-rolebinding.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00007-cilium-olm-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-olm
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-olm
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
@@ -1,0 +1,70 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-cilium-olm
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - hostnetwork
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - create
+      - get
+      - patch
+      - update
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - hubble-server-certs
+      - hubble-relay-client-certs
+      - hubble-relay-server-certs
+    resources:
+      - secrets
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cilium-ca
+    resources:
+      - secrets
+    verbs:
+      - get
+      - update

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00009-cilium-cilium-clusterrole.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00009-cilium-cilium-clusterrole.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-cilium
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/status
+      - pods/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - nodes/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - services
+      - endpoints
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00010-cilium-cilium-olm-clusterrolebinding.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00010-cilium-cilium-olm-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-cilium-olm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-cilium-olm
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00011-cilium-cilium-clusterrolebinding.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00011-cilium-cilium-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-cilium
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00012-cilium-operatorgroup.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00012-cilium-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: cilium
+  namespace: cilium
+spec:
+  targetNamespaces:
+    - cilium

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.15.1-x7095b76-clusterserviceversion.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.15.1-x7095b76-clusterserviceversion.yaml
@@ -1,0 +1,362 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"cilium.io/v1alpha1","kind":"CiliumConfig","metadata":{"name":"cilium-openshift-default","namespace":"cilium"},"spec":{}}]'
+    alm-examples-metadata: '{"cilium-openshift-default":{"description":"Default CiliumConfig
+      CR for OpenShift"}}'
+    capabilities: Seamless Upgrades
+    categories: Networking,Security
+    features.operators.openshift.io/cni: 'true'
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'true'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+    olm.skipRange: '>=1.15.0 <1.15.1+x7095b76'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    repository: http://github.com/cilium/cilium
+    support: support@isovalent.com
+  name: cilium.v1.15.1-x7095b76
+  namespace: cilium
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: CiliumConfig
+        name: ciliumconfigs.cilium.io
+        resources:
+          - kind: DaemonSet
+            name: cilium
+            version: v1
+          - kind: Deployment
+            name: cilium-operator
+            version: v1
+          - kind: ConfigMap
+            name: cilium-config
+            version: v1
+        statusDescriptors:
+          - description: Helm release conditions
+            displayName: Conditions
+            path: conditions
+          - description: Name of deployed Helm release
+            displayName: Deployed release
+            path: deployedRelease
+        version: v1alpha1
+  description: Cilium - eBPF-based Networking, Security, and Observability
+  displayName: Cilium
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iMTE5IiBoZWlnaHQ9IjM1IiB2aWV3Qm94PSIwIDAgMTE5IDM1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI5LjMzNjEgMTguODA3NUgyNC4yMzY4TDIxLjY1NzEgMjMuMzI2MkwyNC4yMzY4IDI3Ljc4MzhIMjkuMzM2MUwzMS45MTU3IDIzLjMyNjJMMjkuMzM2MSAxOC44MDc1WiIgZmlsbD0iIzgwNjFBOSIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI5LjMzNjEgNi44MzkwNUgyNC4yMzY4TDIxLjY1NzEgMTEuMzU3N0wyNC4yMzY4IDE1LjgxNTNIMjkuMzM2MUwzMS45MTU3IDExLjM1NzdMMjkuMzM2MSA2LjgzOTA1WiIgZmlsbD0iI0YxNzMyMyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE5LjA3NzQgMS4xMzk4M0gxMy45NzgxTDExLjM5ODQgNS42NTg1MkwxMy45NzgxIDEwLjExNjFIMTkuMDc3NEwyMS42NTcxIDUuNjU4NTJMMTkuMDc3NCAxLjEzOTgzWiIgZmlsbD0iI0Y4QzUxNyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTguODE4ODkgNi44MzkwNUgzLjcxOTU5TDEuMTM5ODkgMTEuMzU3N0wzLjcxOTU5IDE1LjgxNTNIOC44MTg4OUwxMS4zOTg1IDExLjM1NzdMOC44MTg4OSA2LjgzOTA1WiIgZmlsbD0iI0NBREQ3MiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE5LjA3NzQgMTIuNTM4M0gxMy45NzgxTDExLjM5ODQgMTcuMDU3TDEzLjk3ODEgMjEuNTE0NkgxOS4wNzc0TDIxLjY1NzEgMTcuMDU3TDE5LjA3NzQgMTIuNTM4M1oiIGZpbGw9IiNFODI2MjkiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik04LjgxODg5IDE4LjgwNzVIMy43MTk1OUwxLjEzOTg5IDIzLjMyNjJMMy43MTk1OSAyNy43ODM4SDguODE4ODlMMTEuMzk4NSAyMy4zMjYyTDguODE4ODkgMTguODA3NVoiIGZpbGw9IiM5OEM5M0UiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xOS4wNzc0IDI0LjUwNjdIMTMuOTc4MUwxMS4zOTg0IDI5LjAyNTRMMTMuOTc4MSAzMy40ODNIMTkuMDc3NEwyMS42NTcxIDI5LjAyNTRMMTkuMDc3NCAyNC41MDY3WiIgZmlsbD0iIzYyOEFDNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjgxODEgMjAuNzc4M0gxNC4yMzc3TDExLjkyMDUgMTYuODM5N0wxNC4yMzc3IDEyLjg0NzFIMTguODE4MUwyMS4xMzUyIDE2LjgzOTdMMTguODE4MSAyMC43NzgzWk0xOS42NDQxIDExLjM5ODRIMTMuMzkzM0wxMC4yNTg3IDE2LjgzMUwxMy4zOTMzIDIyLjIyN0gxOS42NDQxTDIyLjc5NyAxNi44MzFMMTkuNjQ0MSAxMS4zOTg0WiIgZmlsbD0iIzM2MzczNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjM5MzIgMjMuMzY2OUwxMC4yNTg3IDI4Ljc5OTVMMTMuMzkzMiAzNC4xOTU0SDE5LjY0NDFMMjIuNzk3IDI4Ljc5OTVMMTkuNjQ0MSAyMy4zNjY5SDEzLjM5MzJaTTExLjkyMDQgMjguODA4MkwxNC4yMzc2IDI0LjgxNTZIMTguODE4TDIxLjEzNTIgMjguODA4MkwxOC44MTggMzIuNzQ2OEgxNC4yMzc2TDExLjkyMDQgMjguODA4MloiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4zOTMyIDBMMTAuMjU4NyA1LjQzMjYzTDEzLjM5MzIgMTAuODI4NUgxOS42NDQxTDIyLjc5NyA1LjQzMjYzTDE5LjY0NDEgMEgxMy4zOTMyWk0xMS45MjA0IDUuNDQxMkwxNC4yMzc2IDEuNDQ4N0gxOC44MThMMjEuMTM1MiA1LjQ0MTJMMTguODE4IDkuMzc5ODVIMTQuMjM3NkwxMS45MjA0IDUuNDQxMloiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMy42NTE4IDE3LjY2NzZMMjAuNTE3MiAyMy4xMDAyTDIzLjY1MTggMjguNDk2MUgyOS45MDI2TDMzLjA1NTUgMjMuMTAwMkwyOS45MDI2IDE3LjY2NzZIMjMuNjUxOFpNMjIuMTc5MSAyMy4xMDg4TDI0LjQ5NjIgMTkuMTE2MkgyOS4wNzY2TDMxLjM5MzcgMjMuMTA4OEwyOS4wNzY2IDI3LjA0NzVIMjQuNDk2MkwyMi4xNzkxIDIzLjEwODhaIiBmaWxsPSIjMzYzNzM2Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjMuNjUxOCA1LjY5OTIyTDIwLjUxNzIgMTEuMTMxOUwyMy42NTE4IDE2LjUyNzhIMjkuOTAyNkwzMy4wNTU1IDExLjEzMTlMMjkuOTAyNiA1LjY5OTIySDIzLjY1MThaTTIyLjE3OTEgMTEuMTQwNUwyNC40OTYyIDcuMTQ3OTFIMjkuMDc2NkwzMS4zOTM3IDExLjE0MDVMMjkuMDc2NiAxNS4wNzkxSDI0LjQ5NjJMMjIuMTc5MSAxMS4xNDA1WiIgZmlsbD0iIzM2MzczNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTMuMTM0NTMgMTcuNjY3NkwwIDIzLjEwMDJMMy4xMzQ1MyAyOC40OTYxSDkuMzg1NDJMMTIuNTM4MyAyMy4xMDAyTDkuMzg1NDIgMTcuNjY3NkgzLjEzNDUzWk0xLjY2MTc5IDIzLjEwODhMMy45Nzg5MiAxOS4xMTYySDguNTU5MzNMMTAuODc2NSAyMy4xMDg4TDguNTU5MzMgMjcuMDQ3NUgzLjk3ODkyTDEuNjYxNzkgMjMuMTA4OFoiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zLjEzNDUzIDUuNjk5MjJMMCAxMS4xMzE5TDMuMTM0NTMgMTYuNTI3OEg5LjM4NTQyTDEyLjUzODMgMTEuMTMxOUw5LjM4NTQyIDUuNjk5MjJIMy4xMzQ1M1pNMS42NjE3OSAxMS4xNDA1TDMuOTc4OTIgNy4xNDc5MUg4LjU1OTMzTDEwLjg3NjUgMTEuMTQwNUw4LjU1OTMzIDE1LjA3OTFIMy45Nzg5MkwxLjY2MTc5IDExLjE0MDVaIiBmaWxsPSIjMzYzNzM2Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTE4LjA0NSAyNi4yMjEySDExNS42ODRDMTE1LjY4IDI2LjE1MTEgMTE1LjY3MiAyNi4wNzkgMTE1LjY3MiAyNi4wMDY3QzExNS42NzEgMjUuNDc1NSAxMTUuNjcyIDI0Ljk0NDMgMTE1LjY3MiAyNC40MTMyQzExNS42NzIgMjEuODE5NiAxMTUuNjcgMTkuMjI1OSAxMTUuNjczIDE2LjYzMjNDMTE1LjY3NCAxNi4wMDA0IDExNS42MDkgMTUuMzc5NyAxMTUuNDEyIDE0Ljc3NjlDMTE1LjA1NCAxMy42NzY5IDExNC4yODUgMTMuMDc1OCAxMTMuMTQ4IDEyLjk0MjNDMTExLjkwMiAxMi43OTYgMTEwLjc4NiAxMy4xMTU1IDEwOS44MDcgMTMuOTA4NUMxMDkuMjQ2IDE0LjM2MzQgMTA4Ljc2IDE0Ljg4ODQgMTA4LjMzNiAxNS40NzA2QzEwOC4yOTEgMTUuNTMyMyAxMDguMjc1IDE1LjYxOTMgMTA4LjI2IDE1LjY5NzJDMTA4LjI0OCAxNS43NTY5IDEwOC4yNTcgMTUuODIwOSAxMDguMjU3IDE1Ljg4MzFDMTA4LjI1NyAxOS4yMjE3IDEwOC4yNTcgMjIuNTYwMyAxMDguMjU3IDI1Ljg5OVYyNi4xNzQ1SDEwNS44MTNDMTA1LjgxIDI2LjA5NjkgMTA1LjgwNCAyNi4wMTc4IDEwNS44MDQgMjUuOTM4NUMxMDUuODAzIDI0LjY0MTYgMTA1LjgwMyAyMy4zNDQ5IDEwNS44MDMgMjIuMDQ4QzEwNS44MDMgMjAuMjEzMSAxMDUuODA0IDE4LjM3ODMgMTA1LjgwMyAxNi41NDM0QzEwNS44MDIgMTUuOTE4OCAxMDUuNzIxIDE1LjMwNDkgMTA1LjUxNiAxNC43MTI3QzEwNS4xNSAxMy42NTI0IDEwNC4zODkgMTMuMDc2IDEwMy4yODkgMTIuOTQzOEMxMDEuOTk1IDEyLjc4ODQgMTAwLjg0NyAxMy4xMzU4IDk5Ljg0ODUgMTMuOTc3N0M5OS4zNTQ4IDE0LjM5NCA5OC45MjcxIDE0Ljg2OCA5OC41NTEzIDE1LjM5MTlDOTguNDY2NyAxNS41MDk3IDk4LjQzIDE1LjYyNzMgOTguNDMwMiAxNS43NzMzQzk4LjQzMzkgMTguMTg3NiA5OC40MzI5IDIwLjYwMTkgOTguNDMyOSAyMy4wMTYyQzk4LjQzMjkgMjQuMDAyNyA5OC40MzI4IDI0Ljk4OTEgOTguNDMyOCAyNS45NzU1Qzk4LjQzMjggMjYuMDUwNiA5OC40MzI5IDI2LjEyNTcgOTguNDMyOSAyNi4xOTY2Qzk4LjI2OCAyNi4yNDExIDk2LjQyMDkgMjYuMjU2OCA5Ni4wMDgzIDI2LjIyMTFDOTUuOTYzNSAyNi4wNzg1IDk1Ljk0NzUgMTEuNTE3OSA5NS45OTE5IDExLjIzMjhDOTYuMTM5MiAxMS4xODk4IDk3LjYyOTkgMTEuMTc5OSA5Ny44NzkxIDExLjIyNEM5OC4wMzE5IDExLjkwNDggOTguMTg2MyAxMi41OTM0IDk4LjM1MDYgMTMuMzI1NUM5OC40MzIxIDEzLjIzNzUgOTguNDgzIDEzLjE4NDggOTguNTMxNSAxMy4xMjk4Qzk4Ljg3MzMgMTIuNzQxOCA5OS4yMTEzIDEyLjM1MyA5OS42MjA3IDEyLjAyODZDMTAwLjI5NyAxMS40OTI1IDEwMS4wMzcgMTEuMTA1IDEwMS44OTIgMTAuOTQ2NUMxMDIuODkxIDEwLjc2MTQgMTAzLjg4MSAxMC43NjkzIDEwNC44NTggMTEuMDY3N0MxMDUuNzQyIDExLjMzNzQgMTA2LjQyOCAxMS44ODM4IDEwNi45ODkgMTIuNjAxNkMxMDcuMjM2IDEyLjkxNzkgMTA3LjQ0MSAxMy4yNjA3IDEwNy42MTggMTMuNjIwOUMxMDcuNjQ3IDEzLjY4MTEgMTA3LjY4IDEzLjc0IDEwNy43MjYgMTMuODI4M0MxMDcuNzg5IDEzLjc0NzEgMTA3LjgzNSAxMy42OTA0IDEwNy44NzggMTMuNjMxOEMxMDguMzYyIDEyLjk3ODggMTA4LjkyNCAxMi40MDQ3IDEwOS41NzggMTEuOTIwOUMxMTAuNjUzIDExLjEyNjkgMTExLjg2NSAxMC43OTIxIDExMy4xODkgMTAuODMwNUMxMTMuNzY1IDEwLjg0NzIgMTE0LjMzMiAxMC45NDA1IDExNC44NzggMTEuMTA5QzExNS45NCAxMS40MzYxIDExNi43ODEgMTIuMDQ4NyAxMTcuMzE5IDEzLjA1MTZDMTE3LjczMiAxMy44MTk4IDExNy45NjEgMTQuNjMyNyAxMTguMDEzIDE1LjQ5NzZDMTE4LjAzNSAxNS44NzU5IDExOC4wNDMgMTYuMjU1NiAxMTguMDQ0IDE2LjYzNDdDMTE4LjA0NiAxOS43Mzg5IDExOC4wNDUgMjIuODQzIDExOC4wNDUgMjUuOTQ3QzExOC4wNDUgMjYuMDM1IDExOC4wNDUgMjYuMTIyOSAxMTguMDQ1IDI2LjIyMTJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTg4Ljk5MSAxMS4yMDg5SDkxLjQyOThDOTEuNDM0NiAxMS4yNzM0IDkxLjQ0MjggMTEuMzMzIDkxLjQ0MjggMTEuMzkyN0M5MS40NDMyIDE0LjQ0ODYgOTEuNDQ2MiAxNy41MDQ2IDkxLjQ0IDIwLjU2MDRDOTEuNDM4NiAyMS4yNDM5IDkxLjM5NzMgMjEuOTMwNCA5MS4yMDUgMjIuNTg5MUM5MC42NzQgMjQuNDA3NyA4OS41MTAzIDI1LjYzMTMgODcuNzA0NSAyNi4yMzA4Qzg3LjE5MDQgMjYuNDAxNSA4Ni42NTYzIDI2LjQ2ODYgODYuMTIxIDI2LjUxODVDODUuMTgxMSAyNi42MDYyIDg0LjI0MjcgMjYuNTcyMSA4My4zMjM4IDI2LjM1MzlDODIuMzAwNiAyNi4xMTEgODEuMzY5MSAyNS42Njg1IDgwLjYzOTcgMjQuODg3MkM3OS45NzMxIDI0LjE3MzMgNzkuNTI5NyAyMy4zMzQ4IDc5LjMxMzEgMjIuMzc0OUM3OS4xNzcgMjEuNzcxOCA3OS4xMTgzIDIxLjE2MTcgNzkuMTE2NiAyMC41NDg2Qzc5LjEwODIgMTcuNDkyNyA3OS4xMTIyIDE0LjQzNjggNzkuMTEyMSAxMS4zODA5Qzc5LjExMjEgMTEuMzMzMyA3OS4xMTYyIDExLjI4NTkgNzkuMTE4MiAxMS4yNDE0Qzc5LjI2NjUgMTEuMTg5MSA4MS4zMDYgMTEuMTc1MiA4MS41NzY0IDExLjIyNzRWMTEuNDg0NkM4MS41NzY0IDE0LjQxNjMgODEuNTc2OSAxNy4zNDggODEuNTc1OSAyMC4yNzk4QzgxLjU3NTggMjAuNzk3OSA4MS41OTYzIDIxLjMxMzIgODEuNzA0MSAyMS44MjI4QzgyLjAxOTUgMjMuMzEzOCA4My4wNDcgMjQuMjY3OSA4NC41NTkzIDI0LjQ2NjRDODUuMTY1OSAyNC41NDU5IDg1Ljc3MjggMjQuNTQxNyA4Ni4zNjk1IDI0LjQwNDFDODcuNDU3MiAyNC4xNTMgODguMTk3OCAyMy40Nzk4IDg4LjYzNDMgMjIuNDY2MkM4OC45MjMyIDIxLjc5NSA4OC45ODc1IDIxLjA3OTggODguOTg5MiAyMC4zNTlDODguOTkzNyAxOC40NDEzIDg4Ljk5MDkgMTYuNTIzNiA4OC45OTEgMTQuNjA1OUM4OC45OTEgMTMuNTY0MyA4OC45OTEgMTIuNTIyNiA4OC45OTEgMTEuNDgxVjExLjIwODlaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTUyLjg4NDggMTMuNjc4N0M1Mi4yOTk4IDEzLjUwNDMgNTEuNzU1MiAxMy4zMzA2IDUxLjIwNCAxMy4xODA5QzUwLjU2MzYgMTMuMDA2OSA0OS45MTA0IDEyLjkwMjkgNDkuMjQzOSAxMi45MDk0QzQ4LjYxMTkgMTIuOTE1NSA0Ny45OTMyIDEzLjAxNDMgNDcuMzk2NCAxMy4yMjA0QzQ2LjU4NTMgMTMuNTAwNCA0NS45MjE3IDEzLjk4OSA0NS40MTQxIDE0LjY4MjhDNDQuNzgwMSAxNS41NDkzIDQ0LjQyMzMgMTYuNTE5MiA0NC4zMjYxIDE3LjU4ODZDNDQuMjY5OCAxOC4yMDgxIDQ0LjI0NTUgMTguODI3MiA0NC4yOSAxOS40NDc4QzQ0LjM2NTEgMjAuNDk4MiA0NC42NTc3IDIxLjQ3NyA0NS4yNDc2IDIyLjM1OTZDNDUuOTM1OSAyMy4zODk0IDQ2LjkwNDQgMjMuOTk0NSA0OC4xMDE3IDI0LjI0OTZDNDguODk5MyAyNC40MTk2IDQ5LjcwNDMgMjQuNDA0OSA1MC41MTAyIDI0LjMxMjdDNTEuMzAyNyAyNC4yMjE5IDUyLjA2MDQgMjMuOTk1NCA1Mi44MDgxIDIzLjcyODhDNTIuODg0OCAyMy43MDE0IDUyLjk2MjkgMjMuNjc4IDUzLjA1NTcgMjMuNjQ3N1YyNS42ODgzQzUyLjg0NzYgMjUuNzg0MSA1Mi42MzYzIDI1LjkwMTYgNTIuNDExNSAyNS45ODE0QzUxLjI5NjIgMjYuMzc3MSA1MC4xMzk5IDI2LjU1NjEgNDguOTYxMSAyNi41NTMyQzQ3LjczMzQgMjYuNTUwMiA0Ni41NTY1IDI2LjI5ODQgNDUuNDQzMyAyNS43NTU5QzQzLjg3MzYgMjQuOTkxMSA0Mi44MjIgMjMuNzc0MyA0Mi4yMjU4IDIyLjE0NzhDNDEuODY5IDIxLjE3NDQgNDEuNzAyNiAyMC4xNjY2IDQxLjY3MiAxOS4xMzE1QzQxLjYzNjIgMTcuOTIxIDQxLjc3NzEgMTYuNzM1OSA0Mi4xNTUxIDE1LjU4NDRDNDIuODgwMSAxMy4zNzYzIDQ0LjM1NDkgMTEuOTA0OSA0Ni41NDI5IDExLjEzNDlDNDcuMDE1NiAxMC45Njg1IDQ3LjUwMTIgMTAuODkxIDQ3Ljk5NzEgMTAuODQ2M0M0OC41NzQ3IDEwLjc5NDMgNDkuMTUxNiAxMC43NTI4IDQ5LjczMTUgMTAuODAwOEM1MC43NjIzIDEwLjg4NjEgNTEuNzY0NSAxMS4wNzg1IDUyLjY5NjIgMTEuNTU2NkM1Mi44Mzg4IDExLjYyOTcgNTIuODkyNyAxMS43MTEyIDUyLjg4OTIgMTEuODczOEM1Mi44Nzc2IDEyLjQwNDYgNTIuODg0OCAxMi45MzU4IDUyLjg4NDggMTMuNDY2OVYxMy42Nzg3WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02NC40NTg5IDI2LjE3MjdINjYuODg1MlYzLjMzMzMxSDY0LjQ1ODlWMjYuMTcyN1oiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNTkuMzg3MiAyNi4xNzU0SDU2Ljk5MDZDNTYuOTc5NiAyNi4xNjczIDU2Ljk3MzEgMjYuMTY0MSA1Ni45Njg4IDI2LjE1OUM1Ni45NjQ1IDI2LjE1NDEgNTYuOTYwNyAyNi4xNDc1IDU2Ljk1OTcgMjYuMTQxMkM1Ni45NTQ2IDI2LjEwNzMgNTYuOTQ2NSAyNi4wNzM0IDU2Ljk0NjUgMjYuMDM5NUM1Ni45NDY4IDIxLjEyMjQgNTYuOTQ3NyAxNi4yMDUyIDU2Ljk0OTEgMTEuMjg4MUM1Ni45NDkyIDExLjI2ODYgNTYuOTU4OSAxMS4yNDkzIDU2Ljk2MzYgMTEuMjMxNEM1Ny4xMTk3IDExLjE5MDEgNTkuMTQ0MSAxMS4xODA5IDU5LjM4NzIgMTEuMjIyMVYyNi4xNzU0WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03MS45NTU4IDExLjIwOTRINzQuMzU5N0M3NC40MDQ2IDExLjM1ODMgNzQuNDE5MSAyNS44OTY2IDc0LjM3MzggMjYuMTcyOEg3MS45NTU4VjExLjIwOTRaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU5LjMzMzYgNy42ODU5N0g1Ni45Mjg5QzU2Ljg4NjQgNy41MzEyNiA1Ni44NzcxIDUuMjE1NjcgNTYuOTE4OCA0Ljk3MTM3SDU5LjMyNEM1OS4zNjM3IDUuMTIwMDYgNTkuMzczOSA3LjQxMDg3IDU5LjMzMzYgNy42ODU5N1oiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNzEuOTEyOCA0Ljk2Mjc3SDc0LjMxMDRDNzQuMzU4OSA1LjEwODY1IDc0LjM3NzggNy4yNjk5MyA3NC4zMzM5IDcuNjc3NDZINzEuOTEyOFY0Ljk2Mjc3WiIgZmlsbD0iYmxhY2siLz4KPC9zdmc+
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - get
+                - patch
+                - update
+                - delete
+                - list
+                - watch
+            - apiGroups:
+                - ''
+              resources:
+                - services/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - cilium.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - '*'
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - update
+            - apiGroups:
+                - ''
+              resources:
+                - services/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - pods/status
+                - pods/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - nodes
+                - nodes/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+                - services
+                - endpoints
+                - componentstatuses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - get
+                - list
+                - watch
+          serviceAccountName: cilium-olm
+      deployments:
+        - name: cilium-olm
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cilium-olm
+            template:
+              metadata:
+                labels:
+                  name: cilium-olm
+              spec:
+                containers:
+                  - command:
+                      - /usr/local/bin/helm-operator
+                      - run
+                      - --watches-file=watches.yaml
+                      - --enable-leader-election
+                      - --leader-election-id=cilium-olm
+                      - --metrics-addr=localhost:8082
+                      - --health-probe-bind-address=localhost:8081
+                      - --zap-log-level=info
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: RELATED_IMAGE_CILIUM
+                        value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+                      - name: RELATED_IMAGE_HUBBLE_RELAY
+                        value: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+                      - name: RELATED_IMAGE_CILIUM_OPERATOR
+                        value: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+                      - name: RELATED_IMAGE_PREFLIGHT
+                        value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+                      - name: RELATED_IMAGE_CLUSTERMESH
+                        value: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+                      - name: RELATED_IMAGE_CERTGEN
+                        value: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+                      - name: RELATED_IMAGE_HUBBLE_UI_BE
+                        value: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+                      - name: RELATED_IMAGE_HUBBLE_UI_FE
+                        value: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+                      - name: RELATED_IMAGE_ETCD_OPERATOR
+                        value: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+                      - name: RELATED_IMAGE_NODEINIT
+                        value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:9ab6be29447125e886300e9258b9a06bedf0a9d87405832aa8b6565ed1ba4215
+                    name: operator
+                    ports:
+                      - containerPort: 9443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 500Mi
+                      requests:
+                        cpu: 100m
+                        memory: 250Mi
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
+                hostNetwork: true
+                serviceAccount: cilium-olm
+                terminationGracePeriodSeconds: 10
+                tolerations:
+                  - operator: Exists
+                volumes:
+                  - emptyDir: {}
+                    name: tmp
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - cilium.io
+              resources:
+                - ciliumconfigs
+                - ciliumconfigs/status
+              verbs:
+                - list
+            - apiGroups:
+                - cilium.io
+              resources:
+                - ciliumconfigs
+                - ciliumconfigs/status
+                - ciliumconfigs/finalizers
+              verbs:
+                - get
+                - patch
+                - update
+                - watch
+                - list
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ''
+              resources:
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - serviceaccounts
+                - configmaps
+                - secrets
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - '*'
+          serviceAccountName: cilium-olm
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - networking
+    - security
+    - observability
+    - eBPF
+  links:
+    - name: Cilium Homepage
+      url: https://cilium.io/
+  maintainers:
+    - email: maintainer@cilium.io
+      name: Cilium
+  maturity: stable
+  provider:
+    name: Isovalent
+  relatedImages:
+    - image: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+      name: cilium
+    - image: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+      name: hubble-relay
+    - image: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+      name: cilium-operator
+    - image: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+      name: preflight
+    - image: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+      name: clustermesh
+    - image: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+      name: certgen
+    - image: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+      name: hubble-ui-backend
+    - image: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+      name: hubble-ui-frontend
+    - image: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+      name: etcd-operator
+    - image: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+      name: nodeinit
+  version: 1.15.1+x7095b76

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -1,0 +1,77 @@
+apiVersion: cilium.io/v1alpha1
+kind: CiliumConfig
+metadata:
+  name: cilium
+  namespace: cilium
+spec:
+  bgpControlPlane:
+    enabled: false
+    secretNamespace:
+      name: cilium
+  bpf:
+    masquerade: true
+  clustermesh:
+    apiserver:
+      service:
+        annotations:
+          lbipam.cilium.io/ips: 192.0.2.20
+        loadBalancerClass: io.cilium/l2-announcer
+        type: LoadBalancer
+    clusters:
+      - ips:
+          - 198.51.100.20
+        name: c-other-cluster-1234
+        port: 2379
+    config:
+      enabled: true
+    useAPIServer: true
+  cni:
+    binPath: /var/lib/cni/bin
+    confPath: /var/run/multus/cni/net.d
+  egressGateway:
+    enabled: false
+  endpointRoutes:
+    enabled: true
+  envoy:
+    enabled: false
+  hubble:
+    metrics:
+      enabled:
+        - httpV2:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+        - dns:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+        - drop:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+      serviceMonitor:
+        enabled: true
+    relay:
+      enabled: true
+    tls:
+      enabled: false
+  ipam:
+    mode: cluster-pool
+    operator:
+      clusterPoolIPv4MaskSize: 23
+      clusterPoolIPv4PodCIDRList:
+        - 10.128.0.0/14
+  k8sClientRateLimit:
+    burst: 30
+    qps: 15
+  kubeProxyReplacement: 'true'
+  l2announcements:
+    enabled: false
+  l7Proxy: true
+  operator:
+    prometheus:
+      enabled: false
+      serviceMonitor:
+        enabled: true
+    resources:
+      limits:
+        cpu: 100m
+        memory: 250Mi
+      requests:
+        cpu: 100m
+        memory: 250Mi
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true


### PR DESCRIPTION
We implement a simple alert which fires if the `cilium_clustermesh_remote_cluster_readiness_status` metric is 0 for 10 minutes.

Additionally, we introduce a new component parameter `alerts` which allows disabling and patching alerts managed through the component as well as configuring additional alerts through the hierarchy.

## TODO

- [x] Make alert tunable via component parameters?

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
