### PR TITLE
Fix check for empty egress range in `NamespaceEgressPolicy`

### DIFF
--- a/component/egress-gateway-policies.jsonnet
+++ b/component/egress-gateway-policies.jsonnet
@@ -90,8 +90,8 @@ local NamespaceEgressPolicy =
       local start = ipval(range.start);
       local end = ipval(range.end);
       local ip = ipval(egress_ip);
-      if start >= end then
-        error 'Egress IP range for "%s" is empty: %s >= %s' % [
+      if start > end then
+        error 'Egress IP range for "%s" is empty: %s > %s' % [
           interface_prefix,
           range.start,
           range.end,


### PR DESCRIPTION
There's no reason to disallow egress ranges with one IP (start == end) when creating namespace policies, since we use inclusive ranges for the rest of the implementation.

The documentation already notes that validation checks whether the first IP is **larger than** the last IP.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
