### PR TITLE
Make field `namespace_egress_ips` in `egress_ip_ranges` optional

### DIFF
--- a/component/egress-gateway-policies.jsonnet
+++ b/component/egress-gateway-policies.jsonnet
@@ -156,16 +156,17 @@ local NamespaceEgressPolicy =
 
 local egress_ip_policies = std.flattenArrays([
   local cfg = params.egress_gateway.egress_ip_ranges[interface_prefix];
+  local ns_egress_ips = std.get(cfg, 'namespace_egress_ips', {});
   [
     NamespaceEgressPolicy(
       interface_prefix,
       cfg.egress_range,
       cfg.node_selector,
-      cfg.namespace_egress_ips[namespace],
-      namespace
+      ns_egress_ips[namespace],
+      namespace,
     )
-    for namespace in std.objectFields(cfg.namespace_egress_ips)
-    if cfg.namespace_egress_ips[namespace] != null
+    for namespace in std.objectFields(ns_egress_ips)
+    if ns_egress_ips[namespace] != null
   ]
   for interface_prefix in std.objectFields(params.egress_gateway.egress_ip_ranges)
   if params.egress_gateway.egress_ip_ranges[interface_prefix] != null

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -364,6 +364,8 @@ The component expects that each value is an object with fields `egress_range`, `
 
 NOTE: Field `shadow_ranges` is optional, see the section on <<_shadow_ranges,shadow ranges>> for more details.
 
+NOTE: Field `namespace_egress_ips` is optional for use cases where only the shadow ranges mechanism is required.
+
 ==== Prerequisites
 
 The component expects that the key for each entry matches the prefix of the dummy interface names that are assigned the shadow IPs which map to the egress IP range defined in `egress_range`.


### PR DESCRIPTION
This is helpful for clusters that use self service namespace egress IPs (cf. #159) as well as clusters that only use the shadow ranges part of `egress_ip_ranges`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
