### PR TITLE
Add support for managing Cilium BGP control plane v2 manifests

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -106,6 +106,10 @@ parameters:
     bgp:
       enabled: false
       peerings: {}
+      cluster_configs: {}
+      peer_configs: {}
+      node_config_overrides: {}
+      advertisements: {}
       loadbalancer_ip_pools: {}
 
     alerts:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -108,6 +108,7 @@ parameters:
       peerings: {}
       cluster_configs: {}
       peer_configs: {}
+      auth_secrets: {}
       node_config_overrides: {}
       advertisements: {}
       loadbalancer_ip_pools: {}

--- a/component/bgp-control-plane.jsonnet
+++ b/component/bgp-control-plane.jsonnet
@@ -16,6 +16,46 @@ local CiliumBGPPeeringPolicy(name) =
     },
   };
 
+local CiliumBGPClusterConfig(name) =
+  kube._Object('cilium.io/v2alpha1', 'CiliumBGPClusterConfig', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+    spec: {},
+  };
+
+local CiliumBGPPeerConfig(name) =
+  kube._Object('cilium.io/v2alpha1', 'CiliumBGPPeerConfig', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+    spec: {},
+  };
+
+local CiliumBGPAdvertisement(name) =
+  kube._Object('cilium.io/v2alpha1', 'CiliumBGPAdvertisement', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+    spec: {},
+  };
+
+local CiliumBGPNodeConfigOverride(name) =
+  kube._Object('cilium.io/v2alpha1', 'CiliumBGPNodeConfigOverride', name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
+    spec: {},
+  };
+
 local render_peering(name, peering) =
   local render_vrouter(config) = config {
     neighbors: std.objectValues(std.mapWithKey(
@@ -37,7 +77,66 @@ local render_peering(name, peering) =
 
 local peerings = com.generateResources(
   std.mapWithKey(render_peering, params.bgp.peerings),
-  CiliumBGPPeeringPolicy
+  std.trace(
+    'CiliumBGPPeeringPolicy is deprecated. ' +
+    'We recommend migrating to BGPv2, see https://hub.syn.tools/cilium/TODO',
+    CiliumBGPPeeringPolicy
+  )
+);
+
+local render_cluster_config(name, config) =
+  local render_instance(name, iconfig) = iconfig {
+    name: name,
+    peers: [
+      iconfig.peers[name] { name: name }
+      for name in std.objectFields(iconfig.peers)
+    ],
+  };
+  {
+    metadata+: std.get(config, 'metadata', {}),
+    spec: {
+      nodeSelector: std.get(config, 'nodeSelector', {}),
+      bgpInstances: std.objectValues(std.mapWithKey(
+        render_instance,
+        config.bgpInstances
+      )),
+    } + com.makeMergeable(std.get(config, 'spec', {})),
+  };
+
+local bgpclusterconfigs = com.generateResources(
+  std.mapWithKey(render_cluster_config, params.bgp.cluster_configs),
+  CiliumBGPClusterConfig
+);
+
+local render_peer_config(name, config) =
+  {
+    metadata+: std.get(config, 'metadata', {}),
+    spec: {
+      families: std.objectValues(std.get(config, 'families', {})),
+    } + com.makeMergeable(std.get(config, 'spec', {})),
+  };
+
+local bgppeerconfigs = com.generateResources(
+  std.mapWithKey(render_peer_config, params.bgp.peer_configs),
+  CiliumBGPPeerConfig
+);
+
+local render_advertisement(name, config) =
+  {
+    metadata+: std.get(config, 'metadata', {}),
+    spec: {
+      advertisements: std.objectValues(std.get(config, 'advertisements', {})),
+    },
+  };
+
+local bgpadvertisements = com.generateResources(
+  std.mapWithKey(render_advertisement, params.bgp.advertisements),
+  CiliumBGPAdvertisement
+);
+
+local bgpnodeconfigoverrides = com.generateResources(
+  params.bgp.node_config_overrides,
+  CiliumBGPNodeConfigOverride
 );
 
 local lb_ip_pools = util.ipPool(params.bgp.loadbalancer_ip_pools);
@@ -45,6 +144,14 @@ local lb_ip_pools = util.ipPool(params.bgp.loadbalancer_ip_pools);
 {
   [if params.bgp.enabled && std.length(peerings) > 0 then
     '40_bgp_peerings']: peerings,
+  [if params.bgp.enabled && std.length(bgpclusterconfigs) > 0 then
+    '40_bgp_cluster_configs']: bgpclusterconfigs,
+  [if params.bgp.enabled && std.length(bgppeerconfigs) > 0 then
+    '40_bgp_peer_configs']: bgppeerconfigs,
+  [if params.bgp.enabled && std.length(bgpadvertisements) > 0 then
+    '40_bgp_advertisements']: bgpadvertisements,
+  [if params.bgp.enabled && std.length(bgpnodeconfigoverrides) > 0 then
+    '40_bgp_node_config_overrides']: bgpnodeconfigoverrides,
   [if params.bgp.enabled && std.length(lb_ip_pools) > 0 then
     '40_loadbalancer_ip_pools']: lb_ip_pools,
 }

--- a/component/bgp-control-plane.jsonnet
+++ b/component/bgp-control-plane.jsonnet
@@ -84,14 +84,60 @@ local peerings = com.generateResources(
   )
 );
 
+local validate_auth_secret(name, config) =
+  local data = std.get(config, 'data', {});
+  local sdata = std.get(config, 'stringData', {});
+  assert
+    std.objectHas(data, 'password') || std.objectHas(sdata, 'password')
+    : "Cilium BGP auth secret `%s` doesn't have key `password`" % name;
+  config;
+
+local authsecrets = com.generateResources(
+  std.mapWithKey(validate_auth_secret, params.bgp.auth_secrets),
+  kube.Secret
+);
+
+local render_peer_config(name, config) =
+  local auth_secret_names = [ o.metadata.name for o in authsecrets ];
+  local validate_peer_config(pconfig) =
+    local secretname = std.get(pconfig.spec, 'authSecretRef');
+    assert
+      secretname == null || std.member(auth_secret_names, secretname)
+      : "CiliumBGPPeerConfig `%s` references auth secret `%s` which doesn't exist"
+        % [ name, secretname ];
+    pconfig;
+  validate_peer_config({
+    metadata+: std.get(config, 'metadata', {}),
+    spec: {
+      families: std.objectValues(std.get(config, 'families', {})),
+    } + com.makeMergeable(std.get(config, 'spec', {})),
+  });
+
+local bgppeerconfigs = com.generateResources(
+  std.mapWithKey(render_peer_config, params.bgp.peer_configs),
+  CiliumBGPPeerConfig
+);
+
 local render_cluster_config(name, config) =
-  local render_instance(name, iconfig) = iconfig {
-    name: name,
-    peers: [
-      iconfig.peers[name] { name: name }
-      for name in std.objectFields(iconfig.peers)
-    ],
-  };
+  local peerConfigNames = [ o.metadata.name for o in bgppeerconfigs ];
+  local validate_peer_config(iname, pconfig) =
+    local pcfgname = std.get(pconfig, 'peerConfigRef', { name: '' }).name;
+    assert
+      std.member(peerConfigNames, pcfgname)
+      : 'Peer `%s` in BGP instance `%s` in CiliumBGPClusterConfig `%s` ' %
+        [ pconfig.name, iname, name ]
+        + "references CiliumBGPPeerConfig `%s` which doesn't exist" %
+          [ pcfgname ];
+    pconfig;
+  local render_instance(name, iconfig) =
+    local cfg = iconfig {
+      name: name,
+      peers: [
+        validate_peer_config(name, iconfig.peers[pname] { name: pname })
+        for pname in std.objectFields(iconfig.peers)
+      ],
+    };
+    cfg;
   {
     metadata+: std.get(config, 'metadata', {}),
     spec: {
@@ -108,18 +154,6 @@ local bgpclusterconfigs = com.generateResources(
   CiliumBGPClusterConfig
 );
 
-local render_peer_config(name, config) =
-  {
-    metadata+: std.get(config, 'metadata', {}),
-    spec: {
-      families: std.objectValues(std.get(config, 'families', {})),
-    } + com.makeMergeable(std.get(config, 'spec', {})),
-  };
-
-local bgppeerconfigs = com.generateResources(
-  std.mapWithKey(render_peer_config, params.bgp.peer_configs),
-  CiliumBGPPeerConfig
-);
 
 local render_advertisement(name, config) =
   {
@@ -139,18 +173,6 @@ local bgpnodeconfigoverrides = com.generateResources(
   CiliumBGPNodeConfigOverride
 );
 
-local validate_auth_secret(name, config) =
-  local data = std.get(config, 'data', {});
-  local sdata = std.get(config, 'stringData', {});
-  assert
-    std.objectHas(data, 'password') || std.objectHas(sdata, 'password')
-    : "Cilium BGP auth secret `%s` doesn't have key `password`" % name;
-  config;
-
-local authsecrets = com.generateResources(
-  std.mapWithKey(validate_auth_secret, params.bgp.auth_secrets),
-  kube.Secret
-);
 
 local lb_ip_pools = util.ipPool(params.bgp.loadbalancer_ip_pools);
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -689,11 +689,20 @@ default:: `false`
 
 Whether to enable the BGP control plane feature in Cilium.
 
+See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/[upstream BGP control plane documentation] for details on the architecture and the individual custom resources mentioned in this section.
+
 === `bgp.peerings`
 
 [horizontal]
 type:: object
 default:: `{}`
+
+[NOTE]
+====
+This parameter is deprecated and will be removed in a future release.
+
+Please use the `cluster_configs`, `peer_configs`, `node_config_overrides` and `advertisements` parameters to configure the Cilium BGP control plane.
+====
 
 This parameter allows users to configure `CiliumBGPPeeringPolicy` resources.
 This resource is used to configure peers for the BGP control plane.
@@ -716,6 +725,237 @@ Make sure to check the upstream documentation for the version of Cilium that you
 The BGP control plane feature is relatively new and sometimes has significant changes between Cilium minor versions.
 ====
 
+=== `bgp.cluster_configs`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure `CiliumBGPClusterConfig` resources.
+
+The `CiliumBGPClusterConfig` resource defines the global BGP configuration and holds the list of peers.
+The resources references one or more `CiliumBGPPeerConfig` resources (see parameter `bgp.peer_configs`) which define the details of each peering connection.
+
+The component creates one `CiliumBGPClusterConfig` for each entry in this parameter.
+The key is used as `metadata.name` of the resulting object.
+
+The component supports fields `bgpInstances`, `nodeSelector`, `metadata` and `spec` in the parameter values.
+Fields `metadata` and `spec` are added to the resulting `CiliumBGPClusterConfig` as is.
+Field `nodeSelector` is used as the value for `spec.nodeSelector`.
+Field `bgpInstances` is expected to be an object and is transformed into entries for `spec.bgpInstances` of the custom resource.
+The keys of the `bgpInstances` field are used for field `name` of the entries for `spec.bgpInstances`.
+The field `peers` of each value of the `bgpInstances` field is expected to be an object and is transformed into a list.
+Again, the keys of field `peers` are used as values for `field` name for the resulting `peers` entries.
+Field `spec` is merged over the partial object generated from fields `nodeSelector` and `bgpInstances`.
+
+See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/#bgp-cluster-configuration[upstream documentation] for all available configuration options.
+
+
+==== Example
+
+The following component parameters snippet is transformed into the `CiliumBGPClusterConfig` shown below.
+
+.component parameters
+[source,yaml]
+----
+bgp:
+  cluster_configs:
+    lb-services:
+      nodeSelector:
+        matchLabels:
+          node-role.kubernetes.io/infra: ''
+      bgpInstances:
+        lbs:
+          localASN: 64512
+          peers:
+            peer1:
+              peerAddress: 192.0.2.2
+              peerASN: 64512
+              peerConfigRef:
+                name: lb-services
+            peer2:
+              peerAddress: 192.0.2.3
+              peerASN: 64512
+              peerConfigRef:
+                name: lb-services
+----
+
+.CiliumBGPClusterConfig
+[source,yaml]
+----
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  bgpInstances:
+    - localASN: 64512
+      name: lbs
+      peers:
+        - name: peer1
+          peerASN: 64512
+          peerAddress: 192.0.2.2
+          peerConfigRef:
+            name: lb-services
+        - name: peer2
+          peerASN: 64512
+          peerAddress: 192.0.2.3
+          peerConfigRef:
+            name: lb-services
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''
+----
+
+=== `bgp.peer_configs`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure `CiliumBGPPeerConfig` resources.
+
+The `CiliumBGPPeerConfig` resource defines a set of BGP peering connection details.
+
+The component creates one `CiliumBGPPeerConfig` for each entry in this parameter.
+The key is used as `metadata.name` of the resulting object.
+The component supports fields `families`, `metadata` and `spec` for each entry.
+Fields `metadata` and `spec` are added to the resulting `CiliumBGPPeerConfig` as is.
+Field `families` is expected to be an object and its values are used as is for field `spec.families`.
+Field `spec` is merged over the partial object created from field `families`.
+
+See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/#bgp-peer-configuration[upstream documentation] for details.
+
+==== Example
+
+.component parameters
+[source,yaml]
+----
+bgp:
+  peer_configs:
+    lb-services:
+      spec:
+        gracefulRestart:
+          enabled: true
+          restartTimeSeconds: 30
+      families:
+        unicast-v4:
+          afi: ipv4
+          safi: unicast
+          advertisements:
+            matchLabels:
+              cilium.syn.tools/advertise: bgp
+----
+
+.CiliumBGPPeerConfig
+[source,yaml]
+----
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  families:
+    - advertisements:
+        matchLabels:
+          cilium.syn.tools/advertise: bgp
+      afi: ipv4
+      safi: unicast
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 30
+----
+
+=== `bgp.node_config_overrides`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure `CiliumBGPNodeConfigOverride` resources.
+
+The `CiliumBGPNodeConfigOverride` resource can be used to inject per-node customizations into the generated `CiliumBGPNodeConfig` resources.
+
+The component creates one `CiliumBGPNodeConfigOverride` for each entry in this parameter.
+The key is used as `metadata.name` of the resulting object.
+The component expects that each value in this parameter is a valid partial `CiliumBGPNodeConfigOverride` resource and doesn't apply any processing.
+
+See the https://docs.cilium.io/en/v1.16/network/bgp-control-plane/bgp-control-plane-v2/#bgp-configuration-override[upstream documentation] for details.
+
+NOTE: The resource name must match the Kubernetes node name of the node for which the configuration is intended.
+
+=== `bgp.advertisements`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure `CiliumBGPAdvertisement` resources.
+
+The component creates one `CiliumBGPAdvertisement` for each entry in this parameter.
+The key is used as `metadata.name` of the resulting object.
+
+The component supports fields `metadata` and `advertisements` for each entry of this parameter.
+Field `metadata` is added to the resulting resource as is.
+Field `advertisements` is expected to be an object, and the values of the object are used for field `spec.advertisements` in the resulting resource without further processing.
+
+See the https://docs.cilium.io/en/v1.16/network/bgp-control-plane/bgp-control-plane-v2/#bgp-advertisements[upstream documentation] for details.
+
+NOTE: The resource name must match the Kubernetes node name of the node for which the configuration is intended.
+
+==== Example
+
+.component parameters
+[source,yaml]
+----
+bgp:
+  advertisements:
+    lb-services:
+      metadata:
+        labels:
+          cilium.syn.tools/advertise: bgp
+      advertisements:
+        lb-ips:
+          advertisementType: Service
+          service:
+            addresses:
+              - LoadBalancerIP
+          selector:
+            matchLabels:
+              syn.tools/load-balancer-class: cilium
+----
+
+.CiliumBGPAdvertisement
+[source,yaml]
+----
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    cilium.syn.tools/advertise: bgp
+    name: lb-services
+  name: lb-services
+spec:
+  advertisements:
+    - advertisementType: Service
+      selector:
+        matchLabels:
+          syn.tools/load-balancer-class: cilium
+      service:
+        addresses:
+          - LoadBalancerIP
+----
+
 === `bgp.loadbalancer_ip_pools`
 
 [horizontal]
@@ -725,7 +965,7 @@ default:: `{}`
 This parameter allows users to configure `CiliumLoadBalancerIPPool` resources.
 This resource is used to configure IP pools which Cilium can use to allocate IPs for services with `type=LoadBalancer`.
 
-The component expects the contents of this parametr to be key value pairs where the value is another object with field `blocks`, and optional fields `serviceSelector` and `spec`.
+The component expects the contents of this parameter to be key value pairs where the value is another object with field `blocks`, and optional fields `serviceSelector` and `spec`.
 The component generates a `CiliumLoadBalancerIPPool` for each entry in the parameter.
 The key of the entry is used as the name of the resulting resource.
 The values of fields `blocks` and `serviceSelector` are processed and used as the base values for fields `spec.blocks` (or `spec.cidrs` in Cilium <= 1.14) and `spec.serviceSelector`.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -748,6 +748,8 @@ The field `peers` of each value of the `bgpInstances` field is expected to be an
 Again, the keys of field `peers` are used as values for `field` name for the resulting `peers` entries.
 Field `spec` is merged over the partial object generated from fields `nodeSelector` and `bgpInstances`.
 
+The component validates that `CiliumBGPClusterConfig` resources only reference `CiliumBGPPeerConfig` resources which are defined in parameter `bgp.peer_configs`.
+
 See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/#bgp-cluster-configuration[upstream documentation] for all available configuration options.
 
 
@@ -827,6 +829,8 @@ The component supports fields `families`, `metadata` and `spec` for each entry.
 Fields `metadata` and `spec` are added to the resulting `CiliumBGPPeerConfig` as is.
 Field `families` is expected to be an object and its values are used as is for field `spec.families`.
 Field `spec` is merged over the partial object created from field `families`.
+
+The component validates that `CiliumBGPPeerConfig` resources only reference BGP auth secret `Secret` resources which are defined in parameter `bgp.auth_secrets`.
 
 See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/#bgp-peer-configuration[upstream documentation] for details.
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -874,6 +874,21 @@ spec:
     restartTimeSeconds: 30
 ----
 
+=== `bgp.auth_secrets`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure `Secret` resources to use as BGP auth secrets.
+
+The component creates one `Secret` for each entry in this parameter.
+The key is used as `metadata.name` of the resulting object.
+The component expects that each value in this parameter is a valid partial `Secret` resource.
+The component validates that each secret has field `password`, which is required by the BGP control plane for auth secrets.
+
+See the https://docs.cilium.io/en/v1.16/network/bgp-control-plane/bgp-control-plane-v2/#md5-password[upstream documentation] for details.
+
 === `bgp.node_config_overrides`
 
 [horizontal]

--- a/tests/bgp-control-plane.yml
+++ b/tests/bgp-control-plane.yml
@@ -34,6 +34,52 @@ parameters:
                 neighbors:
                   - peerAddress: '192.0.2.100/32'
                     peerASN: 64513
+      cluster_configs:
+        lb-services:
+          nodeSelector:
+            matchLabels:
+              node-role.kubernetes.io/infra: ''
+          bgpInstances:
+            lbs:
+              localASN: 64512
+              peers:
+                peer1:
+                  peerAddress: 192.0.2.2
+                  peerASN: 64512
+                  peerConfigRef:
+                    name: lb-services
+                peer2:
+                  peerAddress: 192.0.2.3
+                  peerASN: 64512
+                  peerConfigRef:
+                    name: lb-services
+      peer_configs:
+        lb-services:
+          spec:
+            gracefulRestart:
+              enabled: true
+              restartTimeSeconds: 30
+          families:
+            unicast-v4:
+              afi: ipv4
+              safi: unicast
+              advertisements:
+                matchLabels:
+                  cilium.syn.tools/advertise: bgp
+      advertisements:
+        lb-services:
+          metadata:
+            labels:
+              cilium.syn.tools/advertise: bgp
+          advertisements:
+            lb-ips:
+              advertisementType: Service
+              service:
+                addresses:
+                  - LoadBalancerIP
+              selector:
+                matchLabels:
+                  syn.tools/load-balancer-class: cilium
       loadbalancer_ip_pools:
         lb-services:
           blocks:

--- a/tests/bgp-control-plane.yml
+++ b/tests/bgp-control-plane.yml
@@ -80,6 +80,13 @@ parameters:
               selector:
                 matchLabels:
                   syn.tools/load-balancer-class: cilium
+      auth_secrets:
+        test:
+          data:
+            password: foobar
+        test2:
+          stringData:
+            password: foobar
       loadbalancer_ip_pools:
         lb-services:
           blocks:

--- a/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_advertisements.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_advertisements.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    cilium.syn.tools/advertise: bgp
+    name: lb-services
+  name: lb-services
+spec:
+  advertisements:
+    - advertisementType: Service
+      selector:
+        matchLabels:
+          syn.tools/load-balancer-class: cilium
+      service:
+        addresses:
+          - LoadBalancerIP

--- a/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_auth_secrets.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_auth_secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  password: foobar
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: test
+  name: test
+type: Opaque
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: test2
+  name: test2
+stringData:
+  password: foobar
+type: Opaque

--- a/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_cluster_configs.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_cluster_configs.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  bgpInstances:
+    - localASN: 64512
+      name: lbs
+      peers:
+        - name: peer1
+          peerASN: 64512
+          peerAddress: 192.0.2.2
+          peerConfigRef:
+            name: lb-services
+        - name: peer2
+          peerASN: 64512
+          peerAddress: 192.0.2.3
+          peerConfigRef:
+            name: lb-services
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_peer_configs.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_peer_configs.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  families:
+    - advertisements:
+        matchLabels:
+          cilium.syn.tools/advertise: bgp
+      afi: ipv4
+      safi: unicast
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 30


### PR DESCRIPTION
Th PR adds support for configuring BGP control plane v2 resources (`CiliumBGPClusterConfig` , `CiliumBGPPeerConfig` , `CiliumBGPAdvertisement`, `CiliumBGPNodeConfigOverride` and BGP auth `Secret`). The PR also adds basic validation for the `CiliumBGPPeerConfig` references in `CiliumBGPClusterConfig` resources and the auth secret references in `CiliumBGPPeerConfig`.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
