### PR TITLE
Always deploy BGP auth secrets in the configured secrets namespace

### DIFF
--- a/component/bgp-control-plane.jsonnet
+++ b/component/bgp-control-plane.jsonnet
@@ -53,7 +53,11 @@ local validate_auth_secret(name, config) =
   assert
     std.objectHas(data, 'password') || std.objectHas(sdata, 'password')
     : "Cilium BGP auth secret `%s` doesn't have key `password`" % name;
-  config;
+  config {
+    metadata+: {
+      namespace: params.cilium_helm_values.bgpControlPlane.secretsNamespace.name,
+    },
+  };
 
 local authsecrets = com.generateResources(
   std.mapWithKey(validate_auth_secret, params.bgp.auth_secrets),

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -857,6 +857,11 @@ The key is used as `metadata.name` of the resulting object.
 The component expects that each value in this parameter is a valid partial `Secret` resource.
 The component validates that each secret has field `password`, which is required by the BGP control plane for auth secrets.
 
+By default, the component configures Cilium to look for BGP auth secrets in namespace `cilium`.
+The namespace can be changed by setting Helm value `bgpControlPlane.secretsNamespace.name`.
+
+The component sets `metadata.namespace` to the configured `bgpControlPlane.secretsNamspace.name` for secrets defined through this parameter.
+
 See the https://docs.cilium.io/en/v1.16/network/bgp-control-plane/bgp-control-plane-v2/#md5-password[upstream documentation] for details.
 
 === `bgp.node_config_overrides`

--- a/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_auth_secrets.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/40_bgp_auth_secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     name: test
   name: test
+  namespace: cilium
 type: Opaque
 ---
 apiVersion: v1
@@ -17,6 +18,7 @@ metadata:
   labels:
     name: test2
   name: test2
+  namespace: cilium
 stringData:
   password: foobar
 type: Opaque


### PR DESCRIPTION
We adjust the BGP auth secret generation to always set `metadata.namespace` of the resulting secrets to the configured BGP control plane secrets namespace by reading `cilium_helm_values.bgpControlPlane.secretsNamespace.name`.

This should reduce the potential for unexpected misconfigurations.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
