### PR TITLE
Correctly handle nulled BGP resource configuration entries

### DIFF
--- a/tests/bgp-control-plane.yml
+++ b/tests/bgp-control-plane.yml
@@ -30,6 +30,7 @@ parameters:
                   peerASN: 64512
                   peerConfigRef:
                     name: lb-services
+        test: null
       peer_configs:
         lb-services:
           spec:
@@ -43,6 +44,7 @@ parameters:
               advertisements:
                 matchLabels:
                   cilium.syn.tools/advertise: bgp
+        test: null
       advertisements:
         lb-services:
           metadata:
@@ -57,6 +59,7 @@ parameters:
               selector:
                 matchLabels:
                   syn.tools/load-balancer-class: cilium
+        test: null
       auth_secrets:
         test:
           data:
@@ -64,6 +67,7 @@ parameters:
         test2:
           stringData:
             password: foobar
+        foo: null
       loadbalancer_ip_pools:
         lb-services:
           blocks:


### PR DESCRIPTION
We preprocess the `bgp` parameters which are passed to `com.generateResources()`, so we need to check for null values ourselves in the preprocessing.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
