### PR TITLE
Add support for configuring Enterprise BGP control plane

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0",
+  "commit": "56dd2ee980f197ec2c8b3977c16458e43d0c6ef2",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "Cilium",
       "slug": "cilium",
       "parameter_key": "cilium",
-      "test_cases": "defaults helm-opensource olm-opensource egress-gateway bgp-control-plane kubeproxyreplacement-strict l2-announcement clustermesh",
+      "test_cases": "defaults helm-opensource olm-opensource egress-gateway bgp-control-plane kubeproxyreplacement-strict l2-announcement clustermesh enterprise-bgp",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -25,7 +25,7 @@
       "github_name": "component-cilium",
       "github_url": "https://github.com/projectsyn/component-cilium",
       "_template": "https://github.com/projectsyn/commodore-component-template.git",
-      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
+      "_commit": "56dd2ee980f197ec2c8b3977c16458e43d0c6ef2"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
           - kubeproxyreplacement-strict
           - l2-announcement
           - clustermesh
+          - enterprise-bgp
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -62,6 +63,7 @@ jobs:
           - kubeproxyreplacement-strict
           - l2-announcement
           - clustermesh
+          - enterprise-bgp
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/helm-opensource.yml tests/olm-opensource.yml tests/egress-gateway.yml tests/bgp-control-plane.yml tests/kubeproxyreplacement-strict.yml tests/l2-announcement.yml tests/clustermesh.yml
+test_instances = tests/defaults.yml tests/helm-opensource.yml tests/olm-opensource.yml tests/egress-gateway.yml tests/bgp-control-plane.yml tests/kubeproxyreplacement-strict.yml tests/l2-announcement.yml tests/clustermesh.yml tests/enterprise-bgp.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -105,6 +105,7 @@ parameters:
 
     bgp:
       enabled: false
+      enterprise: false
       cluster_configs: {}
       peer_configs: {}
       auth_secrets: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -691,6 +691,28 @@ Whether to enable the BGP control plane feature in Cilium.
 
 See the https://docs.cilium.io/en/{helm-minor-version}/network/bgp-control-plane/bgp-control-plane-v2/[upstream BGP control plane documentation] for details on the architecture and the individual custom resources mentioned in this section.
 
+=== `bgp.enterprise`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+Whether to enable the enterprise BGP control plane feature in Cilium.
+This parameter has no effect if the component is used to deploy non-enterprise Cilium.
+
+When this parameter is set to `true`, the component will copy the contents of Helm value `bgpControlPlane` to Helm value `enterprise.bgpControlPlane`.
+Additionally, the component will override Helm value `bgpControlPlane.enabled` to `false`, since Cilium doesn't support having both control planes enabled simultaneously.
+This mechanism allows users to switch between the non-enterprise and enterprise BGP control plane without having to manually move Helm values.
+
+See the https://docs.isovalent.com/configuration-guide/networking/bgp/index.html[Enterprise documentation] for details on the enterprise BGP control plane.
+
+[NOTE]
+====
+The component will automatically deploy `IsovalentBGP*` resources instead of `CiliumBGP*` resources for the following parameters when the enterprise control plane is enabled.
+
+The `IsovalentBGP*` resources are structurally equivalent to the `CiliumBGP*` resources, but support the additional enterprise features, such as egress IP announcements.
+====
+
 === `bgp.cluster_configs`
 
 [horizontal]

--- a/tests/enterprise-bgp.yml
+++ b/tests/enterprise-bgp.yml
@@ -1,0 +1,53 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.11.3/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v6.11.3/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
+
+  cilium:
+    install_method: olm
+    release: enterprise
+    __mock_enterprise: true
+    olm:
+      source:
+        enterprise: https://github.com/isovalent/olm-for-cilium/archive/main.tar.gz
+
+    bgp:
+      enabled: true
+      enterprise: true
+      cluster_configs:
+        lb-services:
+          nodeSelector:
+            matchLabels:
+              node-role.kubernetes.io/infra: ''
+          bgpInstances:
+            lbs:
+              localASN: 64512
+              peers:
+                peer1:
+                  peerAddress: 192.0.2.2
+                  peerASN: 64512
+                  peerConfigRef:
+                    name: lb-services
+                peer2:
+                  peerAddress: 192.0.2.3
+                  peerASN: 64512
+                  peerConfigRef:
+                    name: lb-services
+      peer_configs:
+        lb-services:
+          spec:
+            gracefulRestart:
+              enabled: true
+              restartTimeSeconds: 30
+          families:
+            unicast-v4:
+              afi: ipv4
+              safi: unicast
+              advertisements:
+                matchLabels:
+                  cilium.syn.tools/advertise: bgp

--- a/tests/golden/enterprise-bgp/cilium/cilium/02_aggregated_clusterroles.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/02_aggregated_clusterroles.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-cilium-view
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumendpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn-cilium-edit
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-cilium-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-cilium-cluster-reader
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - isovalent.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/enterprise-bgp/cilium/cilium/10_ebpf_alerts.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/10_ebpf_alerts.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-ebpf
+  name: cilium-ebpf
+spec:
+  groups:
+    - name: cilium-ebpf.rules
+      rules:
+        - alert: CiliumBpfMapUtilizationHigh
+          annotations:
+            description: |
+              BPF map utilization for map {{ $labels.map_name }} has been above
+              50% on node {{ $labels.node }} for the last 10m.
+            message: High BPF map utilization on {{ $labels.node }}
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumBpfMapPressureHigh.html
+          expr: cilium_bpf_map_pressure > 0.5
+          for: 10m
+          labels:
+            severity: warning
+        - alert: CiliumBpfMapUtilizationExtremelyHigh
+          annotations:
+            description: |
+              BPF map utilization for map {{ $labels.map_name }} has been above
+              90% on node {{ $labels.node }} for the last 10m.
+            message: Extremely High BPF map utilization on {{ $labels.node }}
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumBpfMapPressureExtremelyHigh.html
+          expr: cilium_bpf_map_pressure > 0.9
+          for: 10m
+          labels:
+            severity: critical
+        - alert: CiliumBpfOperationErrorRateHigh
+          annotations:
+            description: |
+              BPF error rate for map {{ $labels.map_name }} has been above
+              50% on node {{ $labels.node }} for the last 10m.
+            message: High BPF error rate on {{ $labels.node }}
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumBpfOperationErrorRateHigh.html
+          expr: (rate(cilium_bpf_map_ops_total{outcome="fail"}[1m]) / rate(cilium_bpf_map_ops_total{}[1m]))
+            > 0.5
+          for: 10m
+          labels:
+            severity: critical

--- a/tests/golden/enterprise-bgp/cilium/cilium/40_bgp_cluster_configs.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/40_bgp_cluster_configs.yaml
@@ -1,0 +1,26 @@
+apiVersion: isovalent.com/v1alpha1
+kind: IsovalentBGPClusterConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  bgpInstances:
+    - localASN: 64512
+      name: lbs
+      peers:
+        - name: peer1
+          peerASN: 64512
+          peerAddress: 192.0.2.2
+          peerConfigRef:
+            name: lb-services
+        - name: peer2
+          peerASN: 64512
+          peerAddress: 192.0.2.3
+          peerConfigRef:
+            name: lb-services
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ''

--- a/tests/golden/enterprise-bgp/cilium/cilium/40_bgp_peer_configs.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/40_bgp_peer_configs.yaml
@@ -1,0 +1,18 @@
+apiVersion: isovalent.com/v1alpha1
+kind: IsovalentBGPPeerConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: lb-services
+  name: lb-services
+spec:
+  families:
+    - advertisements:
+        matchLabels:
+          cilium.syn.tools/advertise: bgp
+      afi: ipv4
+      safi: unicast
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 30

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/99_cleanup.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/99_cleanup.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cleanup-old-clusterserviceversions
+subjects:
+  - kind: ServiceAccount
+    name: cleanup-old-clusterserviceversions
+    namespace: cilium
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: cleanup-old-clusterserviceversions
+  name: cleanup-old-clusterserviceversions
+  namespace: cilium
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: cleanup-old-clusterserviceversions
+    spec:
+      containers:
+        - args:
+            - |
+              kubectl -n cilium get clusterserviceversion -ojson \
+                | jq '.items[] | select(.spec.version | test("^1.15.1[+]") | not) | .metadata.name' \
+                | xargs --no-run-if-empty kubectl -n cilium delete clusterserviceversions
+          command:
+            - sh
+            - -c
+          env:
+            - name: HOME
+              value: /home
+          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          imagePullPolicy: IfNotPresent
+          name: cleanup-old-clusterserviceversions
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /home
+              name: home
+          workingDir: /home
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: cleanup-old-clusterserviceversions
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: home

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-03-cilium-ciliumconfigs-crd.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-03-cilium-ciliumconfigs-crd.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumconfigs.cilium.io
+spec:
+  group: cilium.io
+  names:
+    kind: CiliumConfig
+    listKind: CiliumConfigList
+    plural: ciliumconfigs
+    singular: ciliumconfig
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the CiliumConfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of CiliumConfig
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status defines the observed state of CiliumConfig
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00000-cilium-namespace.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00000-cilium-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: cilium
+    openshift.io/cluster-logging: 'true'
+    openshift.io/cluster-monitoring: 'true'
+    openshift.io/run-level: '0'
+  name: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00001-cilium-olm-serviceaccount.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00001-cilium-olm-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cilium-olm
+  template:
+    metadata:
+      labels:
+        name: cilium-olm
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/helm-operator
+            - run
+            - --watches-file=watches.yaml
+            - --enable-leader-election
+            - --leader-election-id=cilium-olm
+            - --metrics-addr=localhost:8082
+            - --health-probe-bind-address=localhost:8081
+            - --zap-log-level=info
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RELATED_IMAGE_CILIUM
+              value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+            - name: RELATED_IMAGE_HUBBLE_RELAY
+              value: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+            - name: RELATED_IMAGE_CILIUM_OPERATOR
+              value: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+            - name: RELATED_IMAGE_PREFLIGHT
+              value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+            - name: RELATED_IMAGE_CLUSTERMESH
+              value: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+            - name: RELATED_IMAGE_CERTGEN
+              value: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+            - name: RELATED_IMAGE_HUBBLE_UI_BE
+              value: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+            - name: RELATED_IMAGE_HUBBLE_UI_FE
+              value: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+            - name: RELATED_IMAGE_ETCD_OPERATOR
+              value: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+            - name: RELATED_IMAGE_NODEINIT
+              value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:9ab6be29447125e886300e9258b9a06bedf0a9d87405832aa8b6565ed1ba4215
+          name: operator
+          ports:
+            - containerPort: 9443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 250Mi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      hostNetwork: true
+      serviceAccount: cilium-olm
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      volumes:
+        - emptyDir: {}
+          name: tmp

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00003-cilium-olm-service.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00003-cilium-olm-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: cilium-olm
+  name: cilium-olm
+  namespace: cilium
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443
+  selector:
+    name: cilium-olm

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00004-cilium-olm-leader-election-role.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00004-cilium-olm-leader-election-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-olm-leader-election
+  namespace: cilium
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00005-cilium-olm-role.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-olm
+  namespace: cilium
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumconfigs
+      - ciliumconfigs/status
+    verbs:
+      - list
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumconfigs
+      - ciliumconfigs/status
+      - ciliumconfigs/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+      - watch
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - '*'
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00006-leader-election-rolebinding.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00006-leader-election-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00007-cilium-olm-rolebinding.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00007-cilium-olm-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-olm
+  namespace: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-olm
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00008-cilium-cilium-olm-clusterrole.yaml
@@ -1,0 +1,70 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-cilium-olm
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - hostnetwork
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - create
+      - get
+      - patch
+      - update
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - hubble-server-certs
+      - hubble-relay-client-certs
+      - hubble-relay-server-certs
+    resources:
+      - secrets
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cilium-ca
+    resources:
+      - secrets
+    verbs:
+      - get
+      - update

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00009-cilium-cilium-clusterrole.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00009-cilium-cilium-clusterrole.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-cilium
+rules:
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/status
+      - pods/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - nodes/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - services
+      - endpoints
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00010-cilium-cilium-olm-clusterrolebinding.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00010-cilium-cilium-olm-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-cilium-olm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-cilium-olm
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00011-cilium-cilium-clusterrolebinding.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00011-cilium-cilium-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-cilium
+subjects:
+  - kind: ServiceAccount
+    name: cilium-olm
+    namespace: cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00012-cilium-operatorgroup.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00012-cilium-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: cilium
+  namespace: cilium
+spec:
+  targetNamespaces:
+    - cilium

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.15.1-x7095b76-clusterserviceversion.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-06-cilium-00014-cilium.v1.15.1-x7095b76-clusterserviceversion.yaml
@@ -1,0 +1,362 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"cilium.io/v1alpha1","kind":"CiliumConfig","metadata":{"name":"cilium-openshift-default","namespace":"cilium"},"spec":{}}]'
+    alm-examples-metadata: '{"cilium-openshift-default":{"description":"Default CiliumConfig
+      CR for OpenShift"}}'
+    capabilities: Seamless Upgrades
+    categories: Networking,Security
+    features.operators.openshift.io/cni: 'true'
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'true'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+    olm.skipRange: '>=1.15.0 <1.15.1+x7095b76'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    repository: http://github.com/cilium/cilium
+    support: support@isovalent.com
+  name: cilium.v1.15.1-x7095b76
+  namespace: cilium
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: CiliumConfig
+        name: ciliumconfigs.cilium.io
+        resources:
+          - kind: DaemonSet
+            name: cilium
+            version: v1
+          - kind: Deployment
+            name: cilium-operator
+            version: v1
+          - kind: ConfigMap
+            name: cilium-config
+            version: v1
+        statusDescriptors:
+          - description: Helm release conditions
+            displayName: Conditions
+            path: conditions
+          - description: Name of deployed Helm release
+            displayName: Deployed release
+            path: deployedRelease
+        version: v1alpha1
+  description: Cilium - eBPF-based Networking, Security, and Observability
+  displayName: Cilium
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iMTE5IiBoZWlnaHQ9IjM1IiB2aWV3Qm94PSIwIDAgMTE5IDM1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI5LjMzNjEgMTguODA3NUgyNC4yMzY4TDIxLjY1NzEgMjMuMzI2MkwyNC4yMzY4IDI3Ljc4MzhIMjkuMzM2MUwzMS45MTU3IDIzLjMyNjJMMjkuMzM2MSAxOC44MDc1WiIgZmlsbD0iIzgwNjFBOSIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI5LjMzNjEgNi44MzkwNUgyNC4yMzY4TDIxLjY1NzEgMTEuMzU3N0wyNC4yMzY4IDE1LjgxNTNIMjkuMzM2MUwzMS45MTU3IDExLjM1NzdMMjkuMzM2MSA2LjgzOTA1WiIgZmlsbD0iI0YxNzMyMyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE5LjA3NzQgMS4xMzk4M0gxMy45NzgxTDExLjM5ODQgNS42NTg1MkwxMy45NzgxIDEwLjExNjFIMTkuMDc3NEwyMS42NTcxIDUuNjU4NTJMMTkuMDc3NCAxLjEzOTgzWiIgZmlsbD0iI0Y4QzUxNyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTguODE4ODkgNi44MzkwNUgzLjcxOTU5TDEuMTM5ODkgMTEuMzU3N0wzLjcxOTU5IDE1LjgxNTNIOC44MTg4OUwxMS4zOTg1IDExLjM1NzdMOC44MTg4OSA2LjgzOTA1WiIgZmlsbD0iI0NBREQ3MiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE5LjA3NzQgMTIuNTM4M0gxMy45NzgxTDExLjM5ODQgMTcuMDU3TDEzLjk3ODEgMjEuNTE0NkgxOS4wNzc0TDIxLjY1NzEgMTcuMDU3TDE5LjA3NzQgMTIuNTM4M1oiIGZpbGw9IiNFODI2MjkiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik04LjgxODg5IDE4LjgwNzVIMy43MTk1OUwxLjEzOTg5IDIzLjMyNjJMMy43MTk1OSAyNy43ODM4SDguODE4ODlMMTEuMzk4NSAyMy4zMjYyTDguODE4ODkgMTguODA3NVoiIGZpbGw9IiM5OEM5M0UiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xOS4wNzc0IDI0LjUwNjdIMTMuOTc4MUwxMS4zOTg0IDI5LjAyNTRMMTMuOTc4MSAzMy40ODNIMTkuMDc3NEwyMS42NTcxIDI5LjAyNTRMMTkuMDc3NCAyNC41MDY3WiIgZmlsbD0iIzYyOEFDNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjgxODEgMjAuNzc4M0gxNC4yMzc3TDExLjkyMDUgMTYuODM5N0wxNC4yMzc3IDEyLjg0NzFIMTguODE4MUwyMS4xMzUyIDE2LjgzOTdMMTguODE4MSAyMC43NzgzWk0xOS42NDQxIDExLjM5ODRIMTMuMzkzM0wxMC4yNTg3IDE2LjgzMUwxMy4zOTMzIDIyLjIyN0gxOS42NDQxTDIyLjc5NyAxNi44MzFMMTkuNjQ0MSAxMS4zOTg0WiIgZmlsbD0iIzM2MzczNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjM5MzIgMjMuMzY2OUwxMC4yNTg3IDI4Ljc5OTVMMTMuMzkzMiAzNC4xOTU0SDE5LjY0NDFMMjIuNzk3IDI4Ljc5OTVMMTkuNjQ0MSAyMy4zNjY5SDEzLjM5MzJaTTExLjkyMDQgMjguODA4MkwxNC4yMzc2IDI0LjgxNTZIMTguODE4TDIxLjEzNTIgMjguODA4MkwxOC44MTggMzIuNzQ2OEgxNC4yMzc2TDExLjkyMDQgMjguODA4MloiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4zOTMyIDBMMTAuMjU4NyA1LjQzMjYzTDEzLjM5MzIgMTAuODI4NUgxOS42NDQxTDIyLjc5NyA1LjQzMjYzTDE5LjY0NDEgMEgxMy4zOTMyWk0xMS45MjA0IDUuNDQxMkwxNC4yMzc2IDEuNDQ4N0gxOC44MThMMjEuMTM1MiA1LjQ0MTJMMTguODE4IDkuMzc5ODVIMTQuMjM3NkwxMS45MjA0IDUuNDQxMloiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMy42NTE4IDE3LjY2NzZMMjAuNTE3MiAyMy4xMDAyTDIzLjY1MTggMjguNDk2MUgyOS45MDI2TDMzLjA1NTUgMjMuMTAwMkwyOS45MDI2IDE3LjY2NzZIMjMuNjUxOFpNMjIuMTc5MSAyMy4xMDg4TDI0LjQ5NjIgMTkuMTE2MkgyOS4wNzY2TDMxLjM5MzcgMjMuMTA4OEwyOS4wNzY2IDI3LjA0NzVIMjQuNDk2MkwyMi4xNzkxIDIzLjEwODhaIiBmaWxsPSIjMzYzNzM2Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjMuNjUxOCA1LjY5OTIyTDIwLjUxNzIgMTEuMTMxOUwyMy42NTE4IDE2LjUyNzhIMjkuOTAyNkwzMy4wNTU1IDExLjEzMTlMMjkuOTAyNiA1LjY5OTIySDIzLjY1MThaTTIyLjE3OTEgMTEuMTQwNUwyNC40OTYyIDcuMTQ3OTFIMjkuMDc2NkwzMS4zOTM3IDExLjE0MDVMMjkuMDc2NiAxNS4wNzkxSDI0LjQ5NjJMMjIuMTc5MSAxMS4xNDA1WiIgZmlsbD0iIzM2MzczNiIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTMuMTM0NTMgMTcuNjY3NkwwIDIzLjEwMDJMMy4xMzQ1MyAyOC40OTYxSDkuMzg1NDJMMTIuNTM4MyAyMy4xMDAyTDkuMzg1NDIgMTcuNjY3NkgzLjEzNDUzWk0xLjY2MTc5IDIzLjEwODhMMy45Nzg5MiAxOS4xMTYySDguNTU5MzNMMTAuODc2NSAyMy4xMDg4TDguNTU5MzMgMjcuMDQ3NUgzLjk3ODkyTDEuNjYxNzkgMjMuMTA4OFoiIGZpbGw9IiMzNjM3MzYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zLjEzNDUzIDUuNjk5MjJMMCAxMS4xMzE5TDMuMTM0NTMgMTYuNTI3OEg5LjM4NTQyTDEyLjUzODMgMTEuMTMxOUw5LjM4NTQyIDUuNjk5MjJIMy4xMzQ1M1pNMS42NjE3OSAxMS4xNDA1TDMuOTc4OTIgNy4xNDc5MUg4LjU1OTMzTDEwLjg3NjUgMTEuMTQwNUw4LjU1OTMzIDE1LjA3OTFIMy45Nzg5MkwxLjY2MTc5IDExLjE0MDVaIiBmaWxsPSIjMzYzNzM2Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTE4LjA0NSAyNi4yMjEySDExNS42ODRDMTE1LjY4IDI2LjE1MTEgMTE1LjY3MiAyNi4wNzkgMTE1LjY3MiAyNi4wMDY3QzExNS42NzEgMjUuNDc1NSAxMTUuNjcyIDI0Ljk0NDMgMTE1LjY3MiAyNC40MTMyQzExNS42NzIgMjEuODE5NiAxMTUuNjcgMTkuMjI1OSAxMTUuNjczIDE2LjYzMjNDMTE1LjY3NCAxNi4wMDA0IDExNS42MDkgMTUuMzc5NyAxMTUuNDEyIDE0Ljc3NjlDMTE1LjA1NCAxMy42NzY5IDExNC4yODUgMTMuMDc1OCAxMTMuMTQ4IDEyLjk0MjNDMTExLjkwMiAxMi43OTYgMTEwLjc4NiAxMy4xMTU1IDEwOS44MDcgMTMuOTA4NUMxMDkuMjQ2IDE0LjM2MzQgMTA4Ljc2IDE0Ljg4ODQgMTA4LjMzNiAxNS40NzA2QzEwOC4yOTEgMTUuNTMyMyAxMDguMjc1IDE1LjYxOTMgMTA4LjI2IDE1LjY5NzJDMTA4LjI0OCAxNS43NTY5IDEwOC4yNTcgMTUuODIwOSAxMDguMjU3IDE1Ljg4MzFDMTA4LjI1NyAxOS4yMjE3IDEwOC4yNTcgMjIuNTYwMyAxMDguMjU3IDI1Ljg5OVYyNi4xNzQ1SDEwNS44MTNDMTA1LjgxIDI2LjA5NjkgMTA1LjgwNCAyNi4wMTc4IDEwNS44MDQgMjUuOTM4NUMxMDUuODAzIDI0LjY0MTYgMTA1LjgwMyAyMy4zNDQ5IDEwNS44MDMgMjIuMDQ4QzEwNS44MDMgMjAuMjEzMSAxMDUuODA0IDE4LjM3ODMgMTA1LjgwMyAxNi41NDM0QzEwNS44MDIgMTUuOTE4OCAxMDUuNzIxIDE1LjMwNDkgMTA1LjUxNiAxNC43MTI3QzEwNS4xNSAxMy42NTI0IDEwNC4zODkgMTMuMDc2IDEwMy4yODkgMTIuOTQzOEMxMDEuOTk1IDEyLjc4ODQgMTAwLjg0NyAxMy4xMzU4IDk5Ljg0ODUgMTMuOTc3N0M5OS4zNTQ4IDE0LjM5NCA5OC45MjcxIDE0Ljg2OCA5OC41NTEzIDE1LjM5MTlDOTguNDY2NyAxNS41MDk3IDk4LjQzIDE1LjYyNzMgOTguNDMwMiAxNS43NzMzQzk4LjQzMzkgMTguMTg3NiA5OC40MzI5IDIwLjYwMTkgOTguNDMyOSAyMy4wMTYyQzk4LjQzMjkgMjQuMDAyNyA5OC40MzI4IDI0Ljk4OTEgOTguNDMyOCAyNS45NzU1Qzk4LjQzMjggMjYuMDUwNiA5OC40MzI5IDI2LjEyNTcgOTguNDMyOSAyNi4xOTY2Qzk4LjI2OCAyNi4yNDExIDk2LjQyMDkgMjYuMjU2OCA5Ni4wMDgzIDI2LjIyMTFDOTUuOTYzNSAyNi4wNzg1IDk1Ljk0NzUgMTEuNTE3OSA5NS45OTE5IDExLjIzMjhDOTYuMTM5MiAxMS4xODk4IDk3LjYyOTkgMTEuMTc5OSA5Ny44NzkxIDExLjIyNEM5OC4wMzE5IDExLjkwNDggOTguMTg2MyAxMi41OTM0IDk4LjM1MDYgMTMuMzI1NUM5OC40MzIxIDEzLjIzNzUgOTguNDgzIDEzLjE4NDggOTguNTMxNSAxMy4xMjk4Qzk4Ljg3MzMgMTIuNzQxOCA5OS4yMTEzIDEyLjM1MyA5OS42MjA3IDEyLjAyODZDMTAwLjI5NyAxMS40OTI1IDEwMS4wMzcgMTEuMTA1IDEwMS44OTIgMTAuOTQ2NUMxMDIuODkxIDEwLjc2MTQgMTAzLjg4MSAxMC43NjkzIDEwNC44NTggMTEuMDY3N0MxMDUuNzQyIDExLjMzNzQgMTA2LjQyOCAxMS44ODM4IDEwNi45ODkgMTIuNjAxNkMxMDcuMjM2IDEyLjkxNzkgMTA3LjQ0MSAxMy4yNjA3IDEwNy42MTggMTMuNjIwOUMxMDcuNjQ3IDEzLjY4MTEgMTA3LjY4IDEzLjc0IDEwNy43MjYgMTMuODI4M0MxMDcuNzg5IDEzLjc0NzEgMTA3LjgzNSAxMy42OTA0IDEwNy44NzggMTMuNjMxOEMxMDguMzYyIDEyLjk3ODggMTA4LjkyNCAxMi40MDQ3IDEwOS41NzggMTEuOTIwOUMxMTAuNjUzIDExLjEyNjkgMTExLjg2NSAxMC43OTIxIDExMy4xODkgMTAuODMwNUMxMTMuNzY1IDEwLjg0NzIgMTE0LjMzMiAxMC45NDA1IDExNC44NzggMTEuMTA5QzExNS45NCAxMS40MzYxIDExNi43ODEgMTIuMDQ4NyAxMTcuMzE5IDEzLjA1MTZDMTE3LjczMiAxMy44MTk4IDExNy45NjEgMTQuNjMyNyAxMTguMDEzIDE1LjQ5NzZDMTE4LjAzNSAxNS44NzU5IDExOC4wNDMgMTYuMjU1NiAxMTguMDQ0IDE2LjYzNDdDMTE4LjA0NiAxOS43Mzg5IDExOC4wNDUgMjIuODQzIDExOC4wNDUgMjUuOTQ3QzExOC4wNDUgMjYuMDM1IDExOC4wNDUgMjYuMTIyOSAxMTguMDQ1IDI2LjIyMTJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTg4Ljk5MSAxMS4yMDg5SDkxLjQyOThDOTEuNDM0NiAxMS4yNzM0IDkxLjQ0MjggMTEuMzMzIDkxLjQ0MjggMTEuMzkyN0M5MS40NDMyIDE0LjQ0ODYgOTEuNDQ2MiAxNy41MDQ2IDkxLjQ0IDIwLjU2MDRDOTEuNDM4NiAyMS4yNDM5IDkxLjM5NzMgMjEuOTMwNCA5MS4yMDUgMjIuNTg5MUM5MC42NzQgMjQuNDA3NyA4OS41MTAzIDI1LjYzMTMgODcuNzA0NSAyNi4yMzA4Qzg3LjE5MDQgMjYuNDAxNSA4Ni42NTYzIDI2LjQ2ODYgODYuMTIxIDI2LjUxODVDODUuMTgxMSAyNi42MDYyIDg0LjI0MjcgMjYuNTcyMSA4My4zMjM4IDI2LjM1MzlDODIuMzAwNiAyNi4xMTEgODEuMzY5MSAyNS42Njg1IDgwLjYzOTcgMjQuODg3MkM3OS45NzMxIDI0LjE3MzMgNzkuNTI5NyAyMy4zMzQ4IDc5LjMxMzEgMjIuMzc0OUM3OS4xNzcgMjEuNzcxOCA3OS4xMTgzIDIxLjE2MTcgNzkuMTE2NiAyMC41NDg2Qzc5LjEwODIgMTcuNDkyNyA3OS4xMTIyIDE0LjQzNjggNzkuMTEyMSAxMS4zODA5Qzc5LjExMjEgMTEuMzMzMyA3OS4xMTYyIDExLjI4NTkgNzkuMTE4MiAxMS4yNDE0Qzc5LjI2NjUgMTEuMTg5MSA4MS4zMDYgMTEuMTc1MiA4MS41NzY0IDExLjIyNzRWMTEuNDg0NkM4MS41NzY0IDE0LjQxNjMgODEuNTc2OSAxNy4zNDggODEuNTc1OSAyMC4yNzk4QzgxLjU3NTggMjAuNzk3OSA4MS41OTYzIDIxLjMxMzIgODEuNzA0MSAyMS44MjI4QzgyLjAxOTUgMjMuMzEzOCA4My4wNDcgMjQuMjY3OSA4NC41NTkzIDI0LjQ2NjRDODUuMTY1OSAyNC41NDU5IDg1Ljc3MjggMjQuNTQxNyA4Ni4zNjk1IDI0LjQwNDFDODcuNDU3MiAyNC4xNTMgODguMTk3OCAyMy40Nzk4IDg4LjYzNDMgMjIuNDY2MkM4OC45MjMyIDIxLjc5NSA4OC45ODc1IDIxLjA3OTggODguOTg5MiAyMC4zNTlDODguOTkzNyAxOC40NDEzIDg4Ljk5MDkgMTYuNTIzNiA4OC45OTEgMTQuNjA1OUM4OC45OTEgMTMuNTY0MyA4OC45OTEgMTIuNTIyNiA4OC45OTEgMTEuNDgxVjExLjIwODlaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTUyLjg4NDggMTMuNjc4N0M1Mi4yOTk4IDEzLjUwNDMgNTEuNzU1MiAxMy4zMzA2IDUxLjIwNCAxMy4xODA5QzUwLjU2MzYgMTMuMDA2OSA0OS45MTA0IDEyLjkwMjkgNDkuMjQzOSAxMi45MDk0QzQ4LjYxMTkgMTIuOTE1NSA0Ny45OTMyIDEzLjAxNDMgNDcuMzk2NCAxMy4yMjA0QzQ2LjU4NTMgMTMuNTAwNCA0NS45MjE3IDEzLjk4OSA0NS40MTQxIDE0LjY4MjhDNDQuNzgwMSAxNS41NDkzIDQ0LjQyMzMgMTYuNTE5MiA0NC4zMjYxIDE3LjU4ODZDNDQuMjY5OCAxOC4yMDgxIDQ0LjI0NTUgMTguODI3MiA0NC4yOSAxOS40NDc4QzQ0LjM2NTEgMjAuNDk4MiA0NC42NTc3IDIxLjQ3NyA0NS4yNDc2IDIyLjM1OTZDNDUuOTM1OSAyMy4zODk0IDQ2LjkwNDQgMjMuOTk0NSA0OC4xMDE3IDI0LjI0OTZDNDguODk5MyAyNC40MTk2IDQ5LjcwNDMgMjQuNDA0OSA1MC41MTAyIDI0LjMxMjdDNTEuMzAyNyAyNC4yMjE5IDUyLjA2MDQgMjMuOTk1NCA1Mi44MDgxIDIzLjcyODhDNTIuODg0OCAyMy43MDE0IDUyLjk2MjkgMjMuNjc4IDUzLjA1NTcgMjMuNjQ3N1YyNS42ODgzQzUyLjg0NzYgMjUuNzg0MSA1Mi42MzYzIDI1LjkwMTYgNTIuNDExNSAyNS45ODE0QzUxLjI5NjIgMjYuMzc3MSA1MC4xMzk5IDI2LjU1NjEgNDguOTYxMSAyNi41NTMyQzQ3LjczMzQgMjYuNTUwMiA0Ni41NTY1IDI2LjI5ODQgNDUuNDQzMyAyNS43NTU5QzQzLjg3MzYgMjQuOTkxMSA0Mi44MjIgMjMuNzc0MyA0Mi4yMjU4IDIyLjE0NzhDNDEuODY5IDIxLjE3NDQgNDEuNzAyNiAyMC4xNjY2IDQxLjY3MiAxOS4xMzE1QzQxLjYzNjIgMTcuOTIxIDQxLjc3NzEgMTYuNzM1OSA0Mi4xNTUxIDE1LjU4NDRDNDIuODgwMSAxMy4zNzYzIDQ0LjM1NDkgMTEuOTA0OSA0Ni41NDI5IDExLjEzNDlDNDcuMDE1NiAxMC45Njg1IDQ3LjUwMTIgMTAuODkxIDQ3Ljk5NzEgMTAuODQ2M0M0OC41NzQ3IDEwLjc5NDMgNDkuMTUxNiAxMC43NTI4IDQ5LjczMTUgMTAuODAwOEM1MC43NjIzIDEwLjg4NjEgNTEuNzY0NSAxMS4wNzg1IDUyLjY5NjIgMTEuNTU2NkM1Mi44Mzg4IDExLjYyOTcgNTIuODkyNyAxMS43MTEyIDUyLjg4OTIgMTEuODczOEM1Mi44Nzc2IDEyLjQwNDYgNTIuODg0OCAxMi45MzU4IDUyLjg4NDggMTMuNDY2OVYxMy42Nzg3WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02NC40NTg5IDI2LjE3MjdINjYuODg1MlYzLjMzMzMxSDY0LjQ1ODlWMjYuMTcyN1oiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNTkuMzg3MiAyNi4xNzU0SDU2Ljk5MDZDNTYuOTc5NiAyNi4xNjczIDU2Ljk3MzEgMjYuMTY0MSA1Ni45Njg4IDI2LjE1OUM1Ni45NjQ1IDI2LjE1NDEgNTYuOTYwNyAyNi4xNDc1IDU2Ljk1OTcgMjYuMTQxMkM1Ni45NTQ2IDI2LjEwNzMgNTYuOTQ2NSAyNi4wNzM0IDU2Ljk0NjUgMjYuMDM5NUM1Ni45NDY4IDIxLjEyMjQgNTYuOTQ3NyAxNi4yMDUyIDU2Ljk0OTEgMTEuMjg4MUM1Ni45NDkyIDExLjI2ODYgNTYuOTU4OSAxMS4yNDkzIDU2Ljk2MzYgMTEuMjMxNEM1Ny4xMTk3IDExLjE5MDEgNTkuMTQ0MSAxMS4xODA5IDU5LjM4NzIgMTEuMjIyMVYyNi4xNzU0WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03MS45NTU4IDExLjIwOTRINzQuMzU5N0M3NC40MDQ2IDExLjM1ODMgNzQuNDE5MSAyNS44OTY2IDc0LjM3MzggMjYuMTcyOEg3MS45NTU4VjExLjIwOTRaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU5LjMzMzYgNy42ODU5N0g1Ni45Mjg5QzU2Ljg4NjQgNy41MzEyNiA1Ni44NzcxIDUuMjE1NjcgNTYuOTE4OCA0Ljk3MTM3SDU5LjMyNEM1OS4zNjM3IDUuMTIwMDYgNTkuMzczOSA3LjQxMDg3IDU5LjMzMzYgNy42ODU5N1oiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNzEuOTEyOCA0Ljk2Mjc3SDc0LjMxMDRDNzQuMzU4OSA1LjEwODY1IDc0LjM3NzggNy4yNjk5MyA3NC4zMzM5IDcuNjc3NDZINzEuOTEyOFY0Ljk2Mjc3WiIgZmlsbD0iYmxhY2siLz4KPC9zdmc+
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - get
+                - patch
+                - update
+                - delete
+                - list
+                - watch
+            - apiGroups:
+                - ''
+              resources:
+                - services/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - cilium.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - '*'
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - update
+            - apiGroups:
+                - ''
+              resources:
+                - services/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - pods/status
+                - pods/finalizers
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - nodes
+                - nodes/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+                - services
+                - endpoints
+                - componentstatuses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - get
+                - list
+                - watch
+          serviceAccountName: cilium-olm
+      deployments:
+        - name: cilium-olm
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: cilium-olm
+            template:
+              metadata:
+                labels:
+                  name: cilium-olm
+              spec:
+                containers:
+                  - command:
+                      - /usr/local/bin/helm-operator
+                      - run
+                      - --watches-file=watches.yaml
+                      - --enable-leader-election
+                      - --leader-election-id=cilium-olm
+                      - --metrics-addr=localhost:8082
+                      - --health-probe-bind-address=localhost:8081
+                      - --zap-log-level=info
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: RELATED_IMAGE_CILIUM
+                        value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+                      - name: RELATED_IMAGE_HUBBLE_RELAY
+                        value: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+                      - name: RELATED_IMAGE_CILIUM_OPERATOR
+                        value: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+                      - name: RELATED_IMAGE_PREFLIGHT
+                        value: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+                      - name: RELATED_IMAGE_CLUSTERMESH
+                        value: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+                      - name: RELATED_IMAGE_CERTGEN
+                        value: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+                      - name: RELATED_IMAGE_HUBBLE_UI_BE
+                        value: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+                      - name: RELATED_IMAGE_HUBBLE_UI_FE
+                        value: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+                      - name: RELATED_IMAGE_ETCD_OPERATOR
+                        value: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+                      - name: RELATED_IMAGE_NODEINIT
+                        value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:9ab6be29447125e886300e9258b9a06bedf0a9d87405832aa8b6565ed1ba4215
+                    name: operator
+                    ports:
+                      - containerPort: 9443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 500Mi
+                      requests:
+                        cpu: 100m
+                        memory: 250Mi
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
+                hostNetwork: true
+                serviceAccount: cilium-olm
+                terminationGracePeriodSeconds: 10
+                tolerations:
+                  - operator: Exists
+                volumes:
+                  - emptyDir: {}
+                    name: tmp
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - cilium.io
+              resources:
+                - ciliumconfigs
+                - ciliumconfigs/status
+              verbs:
+                - list
+            - apiGroups:
+                - cilium.io
+              resources:
+                - ciliumconfigs
+                - ciliumconfigs/status
+                - ciliumconfigs/finalizers
+              verbs:
+                - get
+                - patch
+                - update
+                - watch
+                - list
+                - delete
+            - apiGroups:
+                - ''
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - ''
+              resources:
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - serviceaccounts
+                - configmaps
+                - secrets
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - '*'
+          serviceAccountName: cilium-olm
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - networking
+    - security
+    - observability
+    - eBPF
+  links:
+    - name: Cilium Homepage
+      url: https://cilium.io/
+  maintainers:
+    - email: maintainer@cilium.io
+      name: Cilium
+  maturity: stable
+  provider:
+    name: Isovalent
+  relatedImages:
+    - image: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+      name: cilium
+    - image: quay.io/cilium/hubble-relay@sha256:3254aaf85064bc1567e8ce01ad634b6dd269e91858c83be99e47e685d4bb8012
+      name: hubble-relay
+    - image: quay.io/cilium/operator-generic@sha256:819c7281f5a4f25ee1ce2ec4c76b6fbc69a660c68b7825e9580b1813833fa743
+      name: cilium-operator
+    - image: quay.io/cilium/cilium@sha256:351d6685dc6f6ffbcd5451043167cfa8842c6decf80d8c8e426a417c73fb56d4
+      name: preflight
+    - image: quay.io/cilium/clustermesh-apiserver@sha256:b353badd255c2ce47eaa8f394ee4cbf70666773d7294bd887693e0c33503dc37
+      name: clustermesh
+    - image: quay.io/cilium/certgen@sha256:f09fccb919d157fc0a83de20011738192a606250c0ee3238e3610b6cb06c0981
+      name: certgen
+    - image: quay.io/cilium/hubble-ui-backend@sha256:6a396a3674b7d90ff8c408a2e13bc70b7871431bddd63da57afcdeea1d77d27c
+      name: hubble-ui-backend
+    - image: quay.io/cilium/hubble-ui@sha256:cc0d4f6f610409707566087895062ac40960d667dd79e4f33a4f0f393758fc1e
+      name: hubble-ui-frontend
+    - image: quay.io/cilium/cilium-etcd-operator@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
+      name: etcd-operator
+    - image: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
+      name: nodeinit
+  version: 1.15.1+x7095b76

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -1,0 +1,74 @@
+apiVersion: cilium.io/v1alpha1
+kind: CiliumConfig
+metadata:
+  name: cilium
+  namespace: cilium
+spec:
+  cilium:
+    bgpControlPlane:
+      enabled: false
+    bpf:
+      masquerade: true
+    cni:
+      binPath: /var/lib/cni/bin
+      confPath: /var/run/multus/cni/net.d
+    egressGateway:
+      enabled: false
+    endpointRoutes:
+      enabled: true
+    enterprise:
+      bgpControlPlane:
+        enabled: true
+        secretsNamespace:
+          name: cilium
+      egressGatewayHA:
+        enabled: false
+    envoy:
+      enabled: false
+    hubble:
+      metrics:
+        enabled:
+          - httpV2:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+          - dns:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+          - drop:sourceContext=workload|namespace|reserved-identity;destinationContext=workload|namespace|reserved-identity
+        serviceMonitor:
+          enabled: true
+      relay:
+        enabled: true
+      tls:
+        enabled: false
+    ipam:
+      mode: cluster-pool
+      operator:
+        clusterPoolIPv4MaskSize: 23
+        clusterPoolIPv4PodCIDRList:
+          - 10.128.0.0/14
+    k8sClientRateLimit:
+      burst: 30
+      qps: 15
+    kubeProxyReplacement: 'true'
+    l2announcements:
+      enabled: false
+    l7Proxy: true
+    operator:
+      prometheus:
+        enabled: false
+        serviceMonitor:
+          enabled: true
+      resources:
+        limits:
+          cpu: 100m
+          memory: 250Mi
+        requests:
+          cpu: 100m
+          memory: 250Mi
+    prometheus:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+  hubble-enterprise:
+    enabled: false
+    enterprise:
+      enabled: false
+  hubble-ui:
+    enabled: false


### PR DESCRIPTION
The enterprise BGP control plane is required for enterprise-only BGP features (e.g. EGW-HA BGP announcements).




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
