### PR TITLE
Adjust egress IP self service `ManagedResource` for Espejote 0.13.0

### DIFF
--- a/component/espejote-templates/egress-gateway-self-service.jsonnet
+++ b/component/espejote-templates/egress-gateway-self-service.jsonnet
@@ -96,7 +96,7 @@ if esp.triggerName() == 'namespace' then (
   // nsTrigger can be null if we're called when the namespace is getting
   // deleted. If it's not null, we still don't want to do anything when the
   // namespace is getting deleted.
-  if nsTrigger != null && !inDelete(nsTrigger.resource) then
+  if nsTrigger != null && std.get(nsTrigger, 'resource') != null && !inDelete(nsTrigger.resource) then
     reconcileNamespace(nsTrigger.resource)
 ) else
   // Reconcile all namespaces for jsonnetlibrary update or managedresource

--- a/tests/golden/egress-gateway/cilium/cilium/40_egress_ip_managed_resource.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/40_egress_ip_managed_resource.yaml
@@ -514,7 +514,7 @@ spec:
       // nsTrigger can be null if we're called when the namespace is getting
       // deleted. If it's not null, we still don't want to do anything when the
       // namespace is getting deleted.
-      if nsTrigger != null && !inDelete(nsTrigger.resource) then
+      if nsTrigger != null && std.get(nsTrigger, 'resource') != null && !inDelete(nsTrigger.resource) then
         reconcileNamespace(nsTrigger.resource)
     ) else
       // Reconcile all namespaces for jsonnetlibrary update or managedresource


### PR DESCRIPTION
With https://github.com/vshn/espejote/pull/93 `nsTrigger` is no longer null on deleted resources. The PR still keeps the null check for older espejote versions.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
