### PR TITLE
Adjust cilium-operator resource requests and limits for Cilium 1.17

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -70,10 +70,9 @@ parameters:
         resources:
           requests:
             cpu: 100m
-            memory: 250Mi
+            memory: 300Mi
           limits:
-            cpu: 100m
-            memory: 250Mi
+            memory: 500Mi
       clustermesh:
         apiserver:
           metrics:

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -69,11 +69,10 @@ spec:
         enabled: true
     resources:
       limits:
-        cpu: 100m
-        memory: 250Mi
+        memory: 500Mi
       requests:
         cpu: 100m
-        memory: 250Mi
+        memory: 300Mi
   prometheus:
     enabled: true
     serviceMonitor:

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -64,11 +64,10 @@ spec:
           enabled: true
       resources:
         limits:
-          cpu: 100m
-          memory: 250Mi
+          memory: 500Mi
         requests:
           cpu: 100m
-          memory: 250Mi
+          memory: 300Mi
     prometheus:
       enabled: true
       serviceMonitor:

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-operator/deployment.yaml
@@ -83,11 +83,10 @@ spec:
             timeoutSeconds: 3
           resources:
             limits:
-              cpu: 100m
-              memory: 250Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 300Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/cilium/config-map

--- a/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -61,11 +61,10 @@ spec:
         enabled: true
     resources:
       limits:
-        cpu: 100m
-        memory: 250Mi
+        memory: 500Mi
       requests:
         cpu: 100m
-        memory: 250Mi
+        memory: 300Mi
   prometheus:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
We've observed that the cilium-operator uses more memory with Cilium 1.17.

This commit adjusts the memory requests and limits to 300Mi and 500Mi respectively, since we've observed that the 1.17 cilium-operator uses approximately 250-300Mi memory during steady state.

Additionally, the commit updates the component defaults to modernize the operator resource requests and limits a bit: we've decided that having the operator pods with QoS class Guaranteed isn't that useful, it's much better to go with QoS class BestEffort and remove the CPU limits entirely to reduce throttling during startup. This decision also makes the decision to have unequal memory requests and limits much simpler.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
