### PR TITLE
Deploy alert for unexpected Cilium agent pod count

### DIFF
--- a/component/alerts.jsonnet
+++ b/component/alerts.jsonnet
@@ -149,6 +149,45 @@ local ebpf_alerts = prom.PrometheusRule('cilium-ebpf') {
   },
 };
 
+local pods_group = {
+  name: 'cilium-pods.rules',
+  rules: [
+    {
+      local this = self,
+      alert: 'CiliumAgentUnexpectedCount',
+      expr: 'count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"}) != count(kube_node_info)',
+      'for': '5m',
+      labels: {
+        severity: 'critical',
+      },
+      annotations: {
+        runbook_url:
+          'https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html',
+        message: "Number of Cilium agents doesn't match node count",
+        description: |||
+          The cluster has had {{ $value }} Cilium agents for the last %s
+          instead of the expected {{ query "count(kube_node_info)" }}.
+        ||| % this['for'],
+      },
+    },
+  ],
+};
+
+local pods_alerts = prom.PrometheusRule('cilium-pods') {
+  spec+: {
+    groups: [
+      alertpatching.filterPatchRules(
+        pods_group,
+        ignoreNames=ignoreNames,
+        patches=params.alerts.patches,
+        preserveRecordingRules=true,
+        patchNames=false,
+      ),
+    ],
+  },
+};
+
+
 local additional_group =
   local parseRuleName(rname) =
     local rparts = std.splitLimit(rname, ':', 1);
@@ -186,6 +225,8 @@ local additional_alerts = prom.PrometheusRule('cilium-custom') {
     '10_clustermesh_alerts']: clustermesh_alerts,
   [if std.length(ebpf_alerts.spec.groups[0].rules) > 0 then
     '10_ebpf_alerts']: ebpf_alerts,
+  [if std.length(pods_alerts.spec.groups[0].rules) > 0 then
+    '10_pods_alerts']: pods_alerts,
   [if std.length(additional_group.rules) > 0 then
     '10_custom_alerts']: additional_alerts,
 }

--- a/docs/modules/ROOT/pages/runbooks/CiliumAgentUnexpectedCount.adoc
+++ b/docs/modules/ROOT/pages/runbooks/CiliumAgentUnexpectedCount.adoc
@@ -1,0 +1,38 @@
+== CiliumAgentUnexpectedCount
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires if a cluster has a mismatch between the number of Cilium agent pods and nodes for more than 5 minutes.
+
+This usually indicates that the Cilium agent `DaemonSet` is misconfigured or missing.
+
+== icon:bug[] Steps for debugging
+
+. Check the Cilium agent `DaemonSet`
++
+[source,bash]
+----
+kubectl -n cilium get ds -l app.kubernetes.io/name=cilium-agent
+----
+
+.. If the `DaemonSet` is missing, check the OLM operator logs (or Helm deployment status)
++
+[source,bash]
+----
+kubectl -n cilium logs deployment/clife-controller-manager <1>
+----
+<1> For Cilium 1.16, use `deployment/cilium-ee-olm`.
+
+.. If the `DaemonSet` is present, find nodes which don't have a Cilium agent pod and check them for scheduling issues or untolerated taints
++
+[source,bash]
+----
+for node in $(kubectl get nodes -oname); do
+  pod=$(kubectl -oname -n cilium get pods -l app.kubernetes.io/name=cilium-agent --field-selector spec.nodeName="${node#node/}")
+  if [ "${pod}" == "" ]; then
+    echo "Cilium agent missing on node ${node}"
+  fi
+done
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -9,6 +9,8 @@
 ** xref:how-tos/openshift4/upgrade-cilium-oss-to-cilium-enterprise.adoc[Upgrade Cilium OSS to Cilium Enterprise]
 
 .Runbooks
+* Cilium pods
+** xref:runbooks/CiliumAgentUnexpectedCOunt.adoc[]
 * Cluster mesh
 ** xref:runbooks/CiliumClustermeshRemoteClusterNotReady.adoc[]
 ** xref:runbooks/CiliumKVStoreMeshRemoteClusterNotReady.adoc[]

--- a/tests/golden/bgp-control-plane/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/clustermesh/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: cilium

--- a/tests/golden/defaults/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/defaults/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/egress-gateway/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/enterprise-bgp/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/helm-opensource/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/hubble-access/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: cilium

--- a/tests/golden/l2-announcement/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/golden/olm-enterprise/cilium/cilium/10_pods_alerts.yaml
+++ b/tests/golden/olm-enterprise/cilium/cilium/10_pods_alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: cilium-pods
+  name: cilium-pods
+spec:
+  groups:
+    - name: cilium-pods.rules
+      rules:
+        - alert: CiliumAgentUnexpectedCount
+          annotations:
+            description: |
+              The cluster has had {{ $value }} Cilium agents for the last 5m
+              instead of the expected {{ query "count(kube_node_info)" }}.
+            message: Number of Cilium agents doesn't match node count
+            runbook_url: https://hub.syn.tools/cilium/runbooks/CiliumAgentUnexpectedCount.html
+          expr: count(kube_pod_labels{namespace="cilium", label_app_kubernetes_io_name="cilium-agent"})
+            != count(kube_node_info)
+          for: 5m
+          labels:
+            severity: critical


### PR DESCRIPTION
We alert when there's a mismatch between node count and Cilium agent pod count for more than 5 minutes.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
