### PR TITLE
Use `component-openshift4-config` to configure kube-proxy replacement

### DIFF
--- a/component/ocp-manage-kube-proxy.jsonnet
+++ b/component/ocp-manage-kube-proxy.jsonnet
@@ -10,6 +10,29 @@ local fullReplacement = std.member(
   [ 'strict', 'true' ],
   params.cilium_helm_values.kubeProxyReplacement
 );
+
+local configmap = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    annotations: {
+      'syn.tools/source': 'https://github.com/projectsyn/component-cilium.git',
+    },
+    labels: {
+      'app.kubernetes.io/part-of': 'syn',
+      'app.kubernetes.io/component': 'cilium',
+      [inv.parameters.openshift4_config.networking.labelOperator]: '',
+    },
+    name: 'cilium-kubeproxy',
+    namespace: 'openshift-config',
+  },
+  data: {
+    spec: std.manifestJson({
+      deployKubeProxy: !fullReplacement,
+    }),
+  },
+};
+
 local metadataPatch = {
   annotations+: {
     'syn.tools/source': 'https://github.com/projectsyn/component-cilium.git',
@@ -34,15 +57,18 @@ local patch = {
 
 if util.isOpenshift then
   {
-    '99_networkoperator_kube_proxy_patch': [
-      obj {
-        metadata+: metadataPatch,
-      }
-      for obj in esp.clusterScopedObject(
-        inv.parameters.espejote.namespace,
-        patch
-      )
-    ],
+    '99_networkoperator_kube_proxy_patch':
+      if util.supportsOperatorConfigmaps then
+        configmap
+      else [
+        obj {
+          metadata+: metadataPatch,
+        }
+        for obj in esp.clusterScopedObject(
+          inv.parameters.espejote.namespace,
+          patch
+        )
+      ],
   }
 else
   {}

--- a/component/ocp-manage-kube-proxy.jsonnet
+++ b/component/ocp-manage-kube-proxy.jsonnet
@@ -11,28 +11,6 @@ local fullReplacement = std.member(
   params.cilium_helm_values.kubeProxyReplacement
 );
 
-local configmap = {
-  apiVersion: 'v1',
-  kind: 'ConfigMap',
-  metadata: {
-    annotations: {
-      'syn.tools/source': 'https://github.com/projectsyn/component-cilium.git',
-    },
-    labels: {
-      'app.kubernetes.io/part-of': 'syn',
-      'app.kubernetes.io/component': 'cilium',
-      [inv.parameters.openshift4_config.networking.labelOperator]: '',
-    },
-    name: 'cilium-kubeproxy',
-    namespace: 'openshift-config',
-  },
-  data: {
-    spec: std.manifestJson({
-      deployKubeProxy: !fullReplacement,
-    }),
-  },
-};
-
 local metadataPatch = {
   annotations+: {
     'syn.tools/source': 'https://github.com/projectsyn/component-cilium.git',
@@ -55,10 +33,30 @@ local patch = {
   },
 };
 
+local configmap = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    annotations: {
+      'syn.tools/source': 'https://github.com/projectsyn/component-cilium.git',
+    },
+    labels: {
+      'app.kubernetes.io/part-of': 'syn',
+      'app.kubernetes.io/component': 'cilium',
+      [inv.parameters.openshift4_config.networkCustomization.labelOperator]: '',
+    },
+    name: 'cilium-kubeproxy',
+    namespace: 'openshift-config',
+  },
+  data: {
+    spec: std.manifestJson(patch.spec),
+  },
+};
+
 if util.isOpenshift then
   {
     '99_networkoperator_kube_proxy_patch':
-      if util.supportsOperatorConfigmaps then
+      if util.openshiftHasGlobalNetworkOperatorManager then
         configmap
       else [
         obj {

--- a/component/util.libsonnet
+++ b/component/util.libsonnet
@@ -4,7 +4,13 @@ local kube = import 'lib/kube.libjsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.cilium;
+
 local isOpenshift = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
+local supportsOperatorConfigmaps =
+  if !isOpenshift then
+    false
+  else
+    std.get(std.get(inv.parameters.openshift4_config, 'networking', {}), 'enabled', false);
 
 // Parse cilium version
 local parse_version(ver) =
@@ -75,6 +81,7 @@ local render_ip_pools(pools) = com.generateResources(
 
 {
   isOpenshift: isOpenshift,
+  supportsOperatorConfigmaps: supportsOperatorConfigmaps,
   version: version,
   manifestsVersion: manifestsVersion,
   ipPool: render_ip_pools,

--- a/component/util.libsonnet
+++ b/component/util.libsonnet
@@ -6,11 +6,9 @@ local inv = kap.inventory();
 local params = inv.parameters.cilium;
 
 local isOpenshift = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
-local supportsOperatorConfigmaps =
-  if !isOpenshift then
-    false
-  else
-    std.get(std.get(inv.parameters.openshift4_config, 'networking', {}), 'enabled', false);
+local openshiftHasGlobalNetworkOperatorManager =
+  local openshift4_config = std.get(inv.parameters, 'openshift4_config', {});
+  isOpenshift && std.get(std.get(openshift4_config, 'networkCustomization', {}), 'enabled', false);
 
 // Parse cilium version
 local parse_version(ver) =
@@ -81,7 +79,7 @@ local render_ip_pools(pools) = com.generateResources(
 
 {
   isOpenshift: isOpenshift,
-  supportsOperatorConfigmaps: supportsOperatorConfigmaps,
+  openshiftHasGlobalNetworkOperatorManager: openshiftHasGlobalNetworkOperatorManager,
   version: version,
   manifestsVersion: manifestsVersion,
   ipPool: render_ip_pools,

--- a/tests/clustermesh.yml
+++ b/tests/clustermesh.yml
@@ -1,6 +1,5 @@
 applications:
   - espejote
-  - openshift4-config
 
 parameters:
   kapitan:
@@ -19,7 +18,7 @@ parameters:
     namespace: syn-espejote
 
   openshift4_config:
-    networking:
+    networkCustomization:
       enabled: false
 
   facts:

--- a/tests/clustermesh.yml
+++ b/tests/clustermesh.yml
@@ -1,5 +1,6 @@
 applications:
   - espejote
+  - openshift4-config
 
 parameters:
   kapitan:
@@ -16,6 +17,10 @@ parameters:
 
   espejote:
     namespace: syn-espejote
+
+  openshift4_config:
+    networking:
+      enabled: false
 
   facts:
     distribution: openshift4

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/99_networkoperator_kube_proxy_patch.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/99_networkoperator_kube_proxy_patch.yaml
@@ -1,86 +1,16 @@
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    syn.tools/source: https://github.com/projectsyn/component-cilium.git
-  labels:
-    app.kubernetes.io/component: cilium
-    app.kubernetes.io/managed-by: espejote
-    app.kubernetes.io/part-of: syn
-  name: operator-openshift-io-networks-cluster-manager
-  namespace: syn-espejote
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    syn.tools/source: https://github.com/projectsyn/component-cilium.git
-  labels:
-    app.kubernetes.io/component: cilium
-    app.kubernetes.io/managed-by: espejote
-    app.kubernetes.io/part-of: syn
-  name: syn-espejote:operator-openshift-io-networks-cluster-manager
-rules:
-  - apiGroups:
-      - operator.openshift.io
-    resourceNames:
-      - cluster
-    resources:
-      - networks
-    verbs:
-      - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    syn.tools/source: https://github.com/projectsyn/component-cilium.git
-  labels:
-    app.kubernetes.io/component: cilium
-    app.kubernetes.io/managed-by: espejote
-    app.kubernetes.io/part-of: syn
-  name: syn-espejote:operator-openshift-io-networks-cluster-manager
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: syn-espejote:operator-openshift-io-networks-cluster-manager
-subjects:
-  - kind: ServiceAccount
-    name: operator-openshift-io-networks-cluster-manager
-    namespace: syn-espejote
----
-apiVersion: espejote.io/v1alpha1
-kind: ManagedResource
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    syn.tools/source: https://github.com/projectsyn/component-cilium.git
-  labels:
-    app.kubernetes.io/component: cilium
-    app.kubernetes.io/managed-by: espejote
-    app.kubernetes.io/name: operator-openshift-io-networks-cluster-manager
-    app.kubernetes.io/part-of: syn
-  name: operator-openshift-io-networks-cluster-manager
-  namespace: syn-espejote
-spec:
-  applyOptions:
-    force: true
-  serviceAccountRef:
-    name: operator-openshift-io-networks-cluster-manager
-  template: |-
+data:
+  spec: |-
     {
-        "apiVersion": "operator.openshift.io/v1",
-        "kind": "Network",
-        "metadata": {
-            "name": "cluster"
-        },
-        "spec": {
-            "deployKubeProxy": false
-        }
+        "deployKubeProxy": false
     }
-  triggers:
-    - name: target
-      watchResource:
-        apiVersion: operator.openshift.io/v1
-        kind: Network
-        name: cluster
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/projectsyn/component-cilium.git
+  labels:
+    app.kubernetes.io/component: cilium
+    app.kubernetes.io/part-of: syn
+    networking.openshift-config.syn.tools/include-operator: ''
+  name: cilium-kubeproxy
+  namespace: openshift-config

--- a/tests/kubeproxyreplacement-strict.yml
+++ b/tests/kubeproxyreplacement-strict.yml
@@ -1,5 +1,6 @@
 applications:
   - espejote
+  - openshift4-config
 
 parameters:
   kapitan:
@@ -16,6 +17,11 @@ parameters:
 
   espejote:
     namespace: syn-espejote
+
+  openshift4_config:
+    networking:
+      enabled: true
+      labelOperator: 'networking.openshift-config.syn.tools/include-operator'
 
   facts:
     distribution: openshift4

--- a/tests/kubeproxyreplacement-strict.yml
+++ b/tests/kubeproxyreplacement-strict.yml
@@ -1,6 +1,5 @@
 applications:
   - espejote
-  - openshift4-config
 
 parameters:
   kapitan:
@@ -19,7 +18,7 @@ parameters:
     namespace: syn-espejote
 
   openshift4_config:
-    networking:
+    networkCustomization:
       enabled: true
       labelOperator: 'networking.openshift-config.syn.tools/include-operator'
 


### PR DESCRIPTION
This PR uses new features of the openshift4-config component to configure the cluster network. 
Only applies on OpenShift and if the config component supports that feature.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
