### PR TITLE
Remove OpenShift-specific default values from `class/defaults.yml`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -41,9 +41,9 @@ parameters:
       ipam:
         mode: cluster-pool
         operator:
-          clusterPoolIPv4MaskSize: 23
+          clusterPoolIPv4MaskSize: 24
           clusterPoolIPv4PodCIDRList:
-            - 10.128.0.0/14
+            - 10.0.0.0/8
       kubeProxyReplacement: "true"
       egressGateway:
         enabled: ${cilium:egress_gateway:enabled}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -25,7 +25,7 @@ parameters:
           # See also https://github.com/projectsyn/component-cilium/pull/117.
           name: ${cilium:_namespace}
       endpointRoutes:
-        enabled: true
+        enabled: false
       hubble:
         metrics:
           enabled:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -24,9 +24,6 @@ parameters:
           # when installing Cilium with OLM without patching the OLM RBAC.
           # See also https://github.com/projectsyn/component-cilium/pull/117.
           name: ${cilium:_namespace}
-      cni:
-        binPath: /var/lib/cni/bin
-        confPath: /var/run/multus/cni/net.d
       endpointRoutes:
         enabled: true
       hubble:

--- a/component/render-helm-values.jsonnet
+++ b/component/render-helm-values.jsonnet
@@ -158,6 +158,16 @@ local overrideServiceMonitor =
   else
     {};
 
+local openshiftCNIPaths = if util.isOpenshift then
+  {
+    cni+: {
+      binPath: '/var/lib/cni/bin',
+      confPath: '/var/run/multus/cni/net.d',
+    },
+  }
+else
+  {};
+
 local cilium_values = std.prune(
   rewriteLBIPAMRequireLBClass +
   envoyDefault +
@@ -167,7 +177,8 @@ local cilium_values = std.prune(
   forceBPFMasqueradeEgressGW +
   enterpriseBGPControlPlane +
   takeLastHubbleMetricPerOption +
-  overrideServiceMonitor
+  overrideServiceMonitor +
+  openshiftCNIPaths
 );
 
 local cilium_enterprise = {

--- a/docs/modules/ROOT/pages/how-tos/upgrade-to-v4.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-to-v4.adoc
@@ -1,0 +1,116 @@
+= Upgrade component-cilium to v4
+
+== Notable changes
+
+=== Breaking changes
+
+* The Helm value `ipam.operator.clusterPoolIPv4PodCIDRList` is changed to `[10.0.0.0/8]` in the component defaults to match the Helm chart default value
+* The Helm value `ipam.operator.clusterPoolIPv4MaskSize` is changed to `24` in the component defaults to match the Helm chart default value
+* The Helm value `endpointRoutes.enabled` is changed to `false` in the component defaults to match the Helm chart default value
+
+[NOTE]
+====
+We keep explicit defaults for these Helm values.
+This ensures that any potential changes in the Helm chart defaults don't impact existing clusters; in particular potential changes to the Pod CIDR values.
+====
+
+=== Other changes
+
+* OpenShift-specific values for Helm values `cni.binPath` and `cni.confPath` have been moved from component defaults to an OpenShift-specific Helm values overlay applied by the component.
+
+== Preserving the old defaults globally for a Project Syn environment
+
+=== Prerequisites
+
+* Access to your Project Syn environment's global defaults repository
+* Knowledge of how to upgrade a component globally in your environment
+* Knowledge of how to trigger catalog compilations / rollouts globally in your environment
+
+=== Steps
+
+. Add the following configuration in a suitable file in your Project Syn global defaults repository
++
+[source,yaml]
+----
+parameters:
+  cilium:
+    cilium_helm_values:
+      endpointRoutes:
+        enabled: true
+      ipam: <1>
+        operator:
+          clusterPoolIPv4MaskSize: 23
+          ~clusterPoolIPv4PodCIDRList: <2>
+            - 10.128.0.0/14
+----
+<1> We strongly recommend ensuring that you don't modify the `ipam.operator` configurations for existing clusters.
+If you do change these configurations, you'll most likely have to delete all existing pods to restore connectivity.
+<2> We use `~clusterPoolIPv4PodCIDRList` to override the parameter so that the list entry that's added in the component defaults is dropped.
++
+[TIP]
+====
+If you add this configuration in a low priority class in your global defaults, you can omit any sections that you're customizing already in a higher priority class.
+====
+
+. Commit and push the changes in the global defaults repository
+
+. Update the component through your usual mechanisms.
+
+. Trigger cluster compilations through your usual mechanisms.
+
+== Preserving the old defaults for an individual cluster or tenant
+
+=== Prerequisites
+
+* Push access to the cluster's tenant repository
+* Working Commodore installation
+
+=== Steps
+
+. Compile the cluster catalog for the cluster that you want to update
++
+[source,bash]
+----
+CLUSTER_ID=<c-the-cluster-1234> <1>
+----
+<1> Adjust with the cluster's ID
++
+[source,bash]
+----
+commodore catalog compile $CLUSTER_ID
+----
+
+. Update the cluster's or tenant's configuration with the old defaults and update the component
++
+[source,yaml]
+----
+parameters:
+  components:
+    cilium:
+      version: v4.0.0 <1>
+  cilium:
+    cilium_helm_values:
+      endpointRoutes:
+        enabled: true
+      ipam: <2>
+        operator:
+          clusterPoolIPv4MaskSize: 23
+          ~clusterPoolIPv4PodCIDRList: <3>
+            - 10.128.0.0/14
+----
+<1> Check the component's https://github.com/projectsyn/component-cilium/releases[GitHub releases] for the latest v4 version.
+We always recommend updating to recent patch versions of components.
+<2> We strongly recommend ensuring that you don't modify the `ipam.operator` configurations for existing clusters.
+If you do change these configurations, you'll most likely have to delete all existing pods to restore connectivity.
+<3> We use `~clusterPoolIPv4PodCIDRList` to override the parameter so that the list entry that's added in the component defaults is dropped.
++
+IMPORTANT: Omit any fields that you're configuring already through your Project Syn hierarchy.
+
+. Commit and push the changes in the tenant repository
+
+. Compile the cluster and verify that there's no unwanted changes in the resulting diff
++
+[source,bash]
+----
+commodore catalog compile $CLUSTER_ID --push --interactive
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -5,6 +5,7 @@
 
 * xref:how-tos/upgrade-cilium-enterprise.adoc[Upgrade Cilium Enterprise]
 * xref:how-tos/migrate-to-self-service-namespace-egress-ips.adoc[Migrate to self service for namespace egress IPs]
+* xref:how-tos/upgrade-to-v4.adoc[]
 * OpenShift 4
 ** xref:how-tos/openshift4/upgrade-cilium-oss-to-cilium-enterprise.adoc[Upgrade Cilium OSS to Cilium Enterprise]
 

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -226,7 +226,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -256,7 +256,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -393,11 +393,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -22,8 +22,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -44,7 +44,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -52,9 +52,9 @@ spec:
   ipam:
     mode: cluster-pool
     operator:
-      clusterPoolIPv4MaskSize: 23
+      clusterPoolIPv4MaskSize: 24
       clusterPoolIPv4PodCIDRList:
-        - 10.128.0.0/14
+        - 10.0.0.0/8
   k8sClientRateLimit:
     burst: 30
     qps: 15

--- a/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/clustermesh/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -34,7 +34,7 @@ spec:
   egressGateway:
     enabled: false
   endpointRoutes:
-    enabled: true
+    enabled: false
   envoy:
     enabled: false
   hubble:

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -226,7 +226,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -256,7 +256,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -393,11 +393,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -226,7 +226,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -256,7 +256,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -393,11 +393,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -20,7 +20,7 @@ spec:
     egressGateway:
       enabled: false
     endpointRoutes:
-      enabled: true
+      enabled: false
     enterprise:
       bgpControlPlane:
         enabled: true

--- a/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/enterprise-bgp/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -47,9 +47,9 @@ spec:
     ipam:
       mode: cluster-pool
       operator:
-        clusterPoolIPv4MaskSize: 23
+        clusterPoolIPv4MaskSize: 24
         clusterPoolIPv4PodCIDRList:
-          - 10.128.0.0/14
+          - 10.0.0.0/8
     k8sClientRateLimit:
       burst: 30
       qps: 15

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -224,7 +224,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -254,7 +254,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -391,11 +391,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -226,7 +226,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -256,7 +256,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -393,11 +393,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/kubeproxyreplacement-strict/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-agent/daemonset.yaml
@@ -226,7 +226,7 @@ spec:
             - name: CGROUP_ROOT
               value: /run/cilium/cgroupv2
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: mount-cgroup
@@ -256,7 +256,7 @@ spec:
               rm /hostbin/cilium-sysctlfix
           env:
             - name: BIN_PATH
-              value: /var/lib/cni/bin
+              value: /opt/cni/bin
           image: quay.io/cilium/cilium:v1.17.17@sha256:fcda42ceafa241f6745e3a619a6a923b449262fae33fdb76a4a797c9e9266116
           imagePullPolicy: IfNotPresent
           name: apply-sysctl-overwrites
@@ -393,11 +393,11 @@ spec:
             type: DirectoryOrCreate
           name: cilium-cgroup
         - hostPath:
-            path: /var/lib/cni/bin
+            path: /opt/cni/bin
             type: DirectoryOrCreate
           name: cni-path
         - hostPath:
-            path: /var/run/multus/cni/net.d
+            path: /etc/cni/net.d
             type: DirectoryOrCreate
           name: etc-cni-netd
         - hostPath:

--- a/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -21,8 +21,8 @@ data:
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: '0'
   cluster-name: default
-  cluster-pool-ipv4-cidr: 10.128.0.0/14
-  cluster-pool-ipv4-mask-size: '23'
+  cluster-pool-ipv4-cidr: 10.0.0.0/8
+  cluster-pool-ipv4-mask-size: '24'
   clustermesh-enable-endpoint-sync: 'false'
   clustermesh-enable-mcs-api: 'false'
   cni-exclusive: 'true'

--- a/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/cilium/templates/cilium-configmap.yaml
@@ -41,7 +41,6 @@ data:
   enable-bpf-masquerade: 'true'
   enable-endpoint-health-checking: 'true'
   enable-endpoint-lockdown-on-policy-overflow: 'false'
-  enable-endpoint-routes: 'true'
   enable-experimental-lb: 'false'
   enable-health-check-loadbalancer-ip: 'false'
   enable-health-check-nodeport: 'true'

--- a/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -42,9 +42,9 @@ spec:
   ipam:
     mode: cluster-pool
     operator:
-      clusterPoolIPv4MaskSize: 23
+      clusterPoolIPv4MaskSize: 24
       clusterPoolIPv4PodCIDRList:
-        - 10.128.0.0/14
+        - 10.0.0.0/8
   k8sClientRateLimit:
     burst: 30
     qps: 15

--- a/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/olm-enterprise/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -21,7 +21,7 @@ spec:
   egressGateway:
     enabled: false
   endpointRoutes:
-    enabled: true
+    enabled: false
   enterprise:
     egressGatewayHA:
       enabled: false

--- a/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -21,7 +21,7 @@ spec:
     enabled: true
     type: wireguard
   endpointRoutes:
-    enabled: true
+    enabled: false
   envoy:
     enabled: false
   hubble:

--- a/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -39,9 +39,9 @@ spec:
   ipam:
     mode: cluster-pool
     operator:
-      clusterPoolIPv4MaskSize: 23
+      clusterPoolIPv4MaskSize: 24
       clusterPoolIPv4PodCIDRList:
-        - 10.128.0.0/14
+        - 10.0.0.0/8
   k8sClientRateLimit:
     burst: 30
     qps: 15

--- a/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+++ b/tests/golden/transparent-encryption/cilium/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
@@ -15,9 +15,6 @@ spec:
       metrics:
         serviceMonitor:
           enabled: false
-  cni:
-    binPath: /var/lib/cni/bin
-    confPath: /var/run/multus/cni/net.d
   egressGateway:
     enabled: false
   encryption:


### PR DESCRIPTION
This PR changes the component defaults to use the Helm chart defaults for `ipam.operator.clusterPoolIPv4MaskSize`, `ipam.operator.clusterPoolIPv4PodCIDRList` and `endpointRoutes.enabled`. See the how-to included in this PR for more details.

Additionally ,the PR updates `component/render-helm-values.jsonnet` to inject the OpenShift-specific CNI paths when we render the Helm values for OpenShift instead of setting OpenShift-specific paths in `class/defaults.yml`.

Fixes #27 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
