### PR TITLE
Add PSA labels on namespace when deploying via Helm chart

### DIFF
--- a/component/helm-namespace.jsonnet
+++ b/component/helm-namespace.jsonnet
@@ -7,7 +7,7 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.cilium;
 
-local additionalOpenshiftMeta =
+local additionalMeta =
   if util.isOpenshift then
     {
       labels+: {
@@ -20,11 +20,17 @@ local additionalOpenshiftMeta =
       },
     }
   else
-    {};
+    {
+      labels+: {
+        'pod-security.kubernetes.io/audit': 'privileged',
+        'pod-security.kubernetes.io/enforce': 'privileged',
+        'pod-security.kubernetes.io/warn': 'privileged',
+      },
+    };
 
 // Define outputs below
 {
   '00_cilium_namespace': kube.Namespace(params._namespace) {
-    metadata+: additionalOpenshiftMeta,
+    metadata+: additionalMeta,
   },
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -39,6 +39,15 @@ The Cilium OLM is a thin wrapper around Helm, because of this the Helm values ar
 
 NOTE: The component doesn't support the opensource OLM installation anymore, since the newest available opensource OLM tarball is for Cilium 1.15.1.
 
+[TIP]
+====
+The component creates namespace `cilium`.
+For non-OpenShift distributions, the component adds https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces[Pod Security Admission] labels on the namespace to allow pods to use the https://kubernetes.io/docs/concepts/security/pod-security-standards/#privileged[`privileged` Pod Security Standard].
+This ensures that the component can be used to manage Cilium on clusters that enforce Pod Security Standards.
+
+On OpenShift, the `cilium` namespace is provided through the OLM install manifests with suitable labels and annotations.
+====
+
 == `release`
 
 [horizontal]

--- a/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/bgp-control-plane/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium

--- a/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/defaults/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium

--- a/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/egress-gateway/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium

--- a/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/helm-opensource/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium

--- a/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/hubble-access/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium

--- a/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
+++ b/tests/golden/l2-announcement/cilium/cilium/01_cilium_helmchart/00_cilium_namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   annotations: {}
   labels:
     name: cilium
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: cilium


### PR DESCRIPTION
We add all PSA labels (`audit`, `enforce`, `warn`) with level `privileged` to ensure that the Cilium pods are admitted.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
